### PR TITLE
Add test for pausing and unpausing a single route in router-core

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -486,6 +486,34 @@ mod tests {
     }
 
     #[test]
+    fn test_pause_and_unpause_route() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        
+        // Register a route
+        client.register_route(&admin, &name, &addr);
+        
+        // Verify resolve works initially
+        let resolved = client.resolve(&name);
+        assert_eq!(resolved, addr);
+        
+        // Pause the route
+        client.set_route_paused(&admin, &name, &true);
+        
+        // Assert that resolve now fails with RoutePaused error
+        let result = client.try_resolve(&name);
+        assert_eq!(result, Err(Ok(RouterError::RoutePaused)));
+        
+        // Unpause the route
+        client.set_route_paused(&admin, &name, &false);
+        
+        // Assert that resolve works again
+        let resolved = client.resolve(&name);
+        assert_eq!(resolved, addr);
+    }
+
+    #[test]
     fn test_pause_router() {
         let (env, admin, client) = setup();
         let name = String::from_str(&env, "oracle");


### PR DESCRIPTION
- Added test_pause_and_unpause_route() that verifies:
  1. Route can be registered and resolved
  2. Pausing the route causes resolve to fail with RoutePaused error
  3. Unpausing the route allows resolve to work again

This test covers the complete end-to-end pause/unpause functionality for individual routes as specified in issue #18.

closes #18 