### PR TITLE
fix(#13): add MIT license and Rust badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stellar-router
+# stellar-router [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Language: Rust](https://img.shields.io/badge/language-Rust-orange.svg)](https://www.rust-lang.org/)
 
 A modular cross-contract routing infrastructure suite for Stellar/Soroban.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# Task: Add license badge to README.md (#13)
+
+## Steps:
+1. [x] Edit README.md to add MIT license badge after title + optional Rust badge linking to LICENSE
+2. [ ] Commit & push to `blackboxai/license-badge`
+3. [ ] Complete
+
+Current progress: README.md updated with badges.
+


### PR DESCRIPTION
- Added license badge linking to LICENSE file
- Added Rust language badge linking to rust-lang.org
- Placed badges inline after title for visibility

closes #13 