### PR TITLE
fix: remove storage key in revoke_role instead of setting to false

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -139,7 +139,7 @@ impl RouterAccess {
 
         env.storage()
             .instance()
-            .set(&DataKey::HasRole(role, target), &false);
+            .remove(&DataKey::HasRole(role, target));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
revoke_role now removes the storage key entirely instead of setting it to false, preventing accumulation of dead storage entries on Soroban.

## Changes
- Changed revoke_role to use remove() instead of set(..., &false)
- This prevents metered instance storage from accumulating dead entries forever
- has_role still returns false after revocation (unwrap_or(false) handles missing keys correctly)

## Testing
- All existing tests pass
- Behavior unchanged: has_role returns false after revocation

Closes #30