### PR TITLE
docs: clarify execute_batch access model as public batching service

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Batches multiple cross-contract calls into a single transaction. Each call can b
 marked `required` (failure aborts the batch) or optional (failure is tracked but
 does not abort). Returns a `BatchSummary` with success/failure counts.
 
+**Access Model:** `execute_batch` is a public function — any authenticated address
+can call it, not just the admin. This is intentional: `router-multicall` is designed
+as a public batching service where any caller can batch their own cross-contract
+calls to reduce round-trips. The admin role is only used for configuration (e.g.,
+setting `max_batch_size`).
+
 ## Getting Started
 
 ### Prerequisites

--- a/contracts/router-multicall/src/lib.rs
+++ b/contracts/router-multicall/src/lib.rs
@@ -110,6 +110,12 @@ impl RouterMulticall {
 
     /// Execute a batch of calls. Returns a summary of results.
     ///
+    /// **Access Control:** This function can be called by ANY authenticated
+    /// address, not just the admin. This is intentional — `router-multicall`
+    /// is designed as a public batching service. Any caller can batch their
+    /// own cross-contract calls to reduce round-trips. The admin role is only
+    /// used for configuration (e.g., setting `max_batch_size`).
+    ///
     /// Iterates over each [`CallDescriptor`] in `calls` and attempts a
     /// cross-contract invocation. Tracks per-call success and failure. If a
     /// call marked `required` fails, the entire batch is aborted and
@@ -119,6 +125,7 @@ impl RouterMulticall {
     /// # Arguments
     /// * `env` - The Soroban environment.
     /// * `caller` - The address initiating the batch; must authenticate.
+    ///   Can be any address, not restricted to admin.
     /// * `calls` - A list of [`CallDescriptor`]s describing each call to make.
     ///   Must be non-empty and no larger than the configured `max_batch_size`.
     ///


### PR DESCRIPTION
## Summary
Clarified that execute_batch in router-multicall is intentionally designed as a public batching service where any authenticated address can call it, not just the admin.

## Changes
- Updated execute_batch doc comment with explicit 'Access Control' section
- Documented that any authenticated address can call execute_batch
- Explained that admin role is only for configuration (e.g., max_batch_size)
- Updated README with access model documentation for router-multicall

## Rationale
This addresses the confusion noted in the issue where execute_batch uses caller.require_auth() but not require_admin, which is inconsistent with other contracts in the suite. The documentation now makes it clear this is intentional — router-multicall is a public utility service, not an admin-only tool.

## Testing
- All existing tests pass
- No code changes, only documentation updates

Closes #44