### PR TITLE
test: add coverage for set_min_delay, router-core pause/unpause, and registry get_latest edge cases

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -663,6 +663,43 @@ mod tests {
     }
 
     #[test]
+    fn test_update_route_while_paused_succeeds() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr1 = Address::generate(&env);
+        let addr2 = Address::generate(&env);
+        client.register_route(&admin, &name, &addr1);
+        client.set_route_paused(&admin, &name, &true);
+        client.update_route(&admin, &name, &addr2);
+        let entry = client.get_route(&name).unwrap();
+        assert_eq!(entry.address, addr2);
+        assert!(entry.paused); // still paused after update
+    }
+
+    #[test]
+    fn test_resolve_succeeds_after_unpause() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr);
+        client.set_route_paused(&admin, &name, &true);
+        client.set_route_paused(&admin, &name, &false);
+        assert_eq!(client.resolve(&name), addr);
+    }
+
+    #[test]
+    fn test_router_unpause_round_trip() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr);
+        client.set_paused(&admin, &true);
+        assert_eq!(client.try_resolve(&name), Err(Ok(RouterError::RouterPaused)));
+        client.set_paused(&admin, &false);
+        assert_eq!(client.resolve(&name), addr);
+    }
+
+    #[test]
     fn test_get_all_routes_multiple() {
         let (env, admin, client) = setup();
         let oracle = String::from_str(&env, "oracle");

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -402,6 +402,39 @@ mod tests {
     }
 
     #[test]
+    fn test_get_latest_unknown_name_returns_not_found() {
+        let (env, _admin, client) = setup();
+        let name = String::from_str(&env, "unknown");
+        let result = client.try_get_latest(&name);
+        assert_eq!(result, Err(Ok(RegistryError::NotFound)));
+    }
+
+    #[test]
+    fn test_get_latest_returns_not_found_when_all_deprecated() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register(&admin, &name, &addr, &1);
+        client.deprecate(&admin, &name, &1);
+        let result = client.try_get_latest(&name);
+        assert_eq!(result, Err(Ok(RegistryError::NotFound)));
+    }
+
+    #[test]
+    fn test_get_latest_skips_multiple_deprecated_versions() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let (a1, a2, a3) = (Address::generate(&env), Address::generate(&env), Address::generate(&env));
+        client.register(&admin, &name, &a1, &1);
+        client.register(&admin, &name, &a2, &2);
+        client.register(&admin, &name, &a3, &3);
+        client.deprecate(&admin, &name, &3);
+        client.deprecate(&admin, &name, &2);
+        let latest = client.get_latest(&name);
+        assert_eq!(latest.version, 1);
+    }
+
+    #[test]
     fn test_duplicate_version_fails() {
         let (env, admin, client) = setup();
         let name = String::from_str(&env, "oracle");

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -571,6 +571,43 @@ mod tests {
     }
 
     #[test]
+    fn test_set_min_delay_updates_value() {
+        let (env, admin, client) = setup();
+        client.set_min_delay(&admin, &7200);
+        assert_eq!(client.min_delay(), 7200);
+    }
+
+    #[test]
+    fn test_set_min_delay_zero_fails() {
+        let (env, admin, client) = setup();
+        let result = client.try_set_min_delay(&admin, &0);
+        assert_eq!(result, Err(Ok(TimelockError::InvalidDelay)));
+    }
+
+    #[test]
+    fn test_set_min_delay_unauthorized_fails() {
+        let (env, _admin, client) = setup();
+        let attacker = Address::generate(&env);
+        let result = client.try_set_min_delay(&attacker, &7200);
+        assert_eq!(result, Err(Ok(TimelockError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_set_min_delay_does_not_affect_existing_ops() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        // Queue with current min_delay of 3600
+        let op_id = client.queue(&admin, &desc, &target, &3600);
+        // Raise min_delay to 7200 — op was already queued with delay=3600
+        client.set_min_delay(&admin, &7200);
+        // Advance past the original ETA
+        env.ledger().with_mut(|l| l.timestamp += 3601);
+        // Execute must still succeed — the op was valid when queued
+        assert!(client.try_execute(&admin, &op_id).is_ok());
+    }
+
+    #[test]
     fn test_old_admin_locked_out_after_transfer() {
         let (env, admin, client) = setup();
         let new_admin = Address::generate(&env);


### PR DESCRIPTION


- router-timelock: add tests for set_min_delay (updates value, zero fails, unauthorized fails, does not affect already-queued ops) (#40)
- router-core: add tests for update_route while paused, resolve after per-route unpause, and global router unpause round-trip (#42)
- router-registry: add tests for get_latest when name is unknown, all versions deprecated, and multiple deprecated versions skipped (#43

Closes #34 
Closes #40 
Closes #42 
Closes #43 