### PR TITLE
fix(registry): return VersionNotFound on deprecate of missing version…

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -11,7 +11,7 @@
 //! - Check role membership on-chain
 //! - Whitelist/blacklist individual callers
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, String, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, String, Symbol, Vec};
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
@@ -21,6 +21,8 @@ pub enum DataKey {
     HasRole(String, Address),   // (role, address) -> bool
     RoleAdmin(String),          // role -> Address who manages it
     Blacklisted(Address),
+    RoleMembers(String),        // role -> Vec<Address>
+    AddressRoles(Address),      // address -> Vec<String>
 }
 
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -104,14 +106,25 @@ impl RouterAccess {
         env.storage()
             .instance()
             .set(&DataKey::HasRole(role.clone(), target.clone()), &true);
+
+        let mut members: Vec<Address> = env.storage().instance()
+            .get(&DataKey::RoleMembers(role.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        members.push_back(target.clone());
+        env.storage().instance().set(&DataKey::RoleMembers(role.clone()), &members);
+
+        let mut roles: Vec<String> = env.storage().instance()
+            .get(&DataKey::AddressRoles(target.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        roles.push_back(role.clone());
+        env.storage().instance().set(&DataKey::AddressRoles(target.clone()), &roles);
+
         env.events().publish(
             (Symbol::new(&env, "role_granted"),),
             (role, target),
         );
         Ok(())
     }
-
-    /// Revoke a role from an address.
     ///
     /// Removes `role` from `target`. The `target` must currently hold the role.
     /// The `caller` must be either the super-admin or the designated admin for `role`.
@@ -144,6 +157,23 @@ impl RouterAccess {
         env.storage()
             .instance()
             .remove(&DataKey::HasRole(role.clone(), target.clone()));
+
+        let mut members: Vec<Address> = env.storage().instance()
+            .get(&DataKey::RoleMembers(role.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        if let Some(i) = members.iter().position(|a| a == target) {
+            members.remove(i as u32);
+        }
+        env.storage().instance().set(&DataKey::RoleMembers(role.clone()), &members);
+
+        let mut roles: Vec<String> = env.storage().instance()
+            .get(&DataKey::AddressRoles(target.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        if let Some(i) = roles.iter().position(|r| r == role) {
+            roles.remove(i as u32);
+        }
+        env.storage().instance().set(&DataKey::AddressRoles(target.clone()), &roles);
+
         env.events().publish(
             (Symbol::new(&env, "role_revoked"),),
             (role, target),
@@ -276,6 +306,20 @@ impl RouterAccess {
         Self::is_blacklisted_internal(&env, &target)
     }
 
+    /// Return all addresses currently holding `role`.
+    pub fn get_role_members(env: Env, role: String) -> Vec<Address> {
+        env.storage().instance()
+            .get(&DataKey::RoleMembers(role))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Return all roles currently held by `addr`.
+    pub fn get_roles_for_address(env: Env, addr: Address) -> Vec<String> {
+        env.storage().instance()
+            .get(&DataKey::AddressRoles(addr))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
     /// Transfer super-admin to a new address.
     ///
     /// Replaces the current super-admin with `new_admin`. The `current` address
@@ -385,7 +429,6 @@ mod tests {
         Env,
         IntoVal,
         String,
-        Val,
     };
 
     fn setup() -> (Env, Address, RouterAccessClient<'static>) {
@@ -418,8 +461,9 @@ mod tests {
         let event = env.events().all().last().unwrap().clone();
         assert_eq!(event.0, client.address);
         assert_eq!(event.1, vec![&env, Symbol::new(&env, "role_granted").into_val(&env)]);
-        let expected_data: Val = (role, user).into_val(&env);
-        assert_eq!(event.2, expected_data);
+        let (got_role, got_user): (String, Address) = event.2.into_val(&env);
+        assert_eq!(got_role, role);
+        assert_eq!(got_user, user);
     }
 
     #[test]
@@ -444,8 +488,9 @@ mod tests {
         let event = env.events().all().last().unwrap().clone();
         assert_eq!(event.0, client.address);
         assert_eq!(event.1, vec![&env, Symbol::new(&env, "role_revoked").into_val(&env)]);
-        let expected_data: Val = (role, user).into_val(&env);
-        assert_eq!(event.2, expected_data);
+        let (got_role, got_user): (String, Address) = event.2.into_val(&env);
+        assert_eq!(got_role, role);
+        assert_eq!(got_user, user);
     }
 
     #[test]
@@ -481,8 +526,8 @@ mod tests {
             event.1,
             vec![&env, Symbol::new(&env, "address_blacklisted").into_val(&env)]
         );
-        let expected_data: Val = user.into_val(&env);
-        assert_eq!(event.2, expected_data);
+        let got_user: Address = event.2.into_val(&env);
+        assert_eq!(got_user, user);
     }
 
     #[test]
@@ -534,8 +579,9 @@ mod tests {
             event.1,
             vec![&env, Symbol::new(&env, "admin_transferred").into_val(&env)]
         );
-        let expected_data: Val = (admin, new_admin).into_val(&env);
-        assert_eq!(event.2, expected_data);
+        let (old, new): (Address, Address) = event.2.into_val(&env);
+        assert_eq!(old, admin);
+        assert_eq!(new, new_admin);
     }
 
     #[test]
@@ -632,7 +678,51 @@ mod tests {
             event.1,
             vec![&env, Symbol::new(&env, "address_unblacklisted").into_val(&env)]
         );
-        let expected_data: Val = user.into_val(&env);
-        assert_eq!(event.2, expected_data);
+        let got_user: Address = event.2.into_val(&env);
+        assert_eq!(got_user, user);
+    }
+
+    #[test]
+    fn test_get_role_members() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "operator");
+        let u1 = Address::generate(&env);
+        let u2 = Address::generate(&env);
+
+        assert!(client.get_role_members(&role).is_empty());
+
+        client.grant_role(&admin, &role, &u1);
+        client.grant_role(&admin, &role, &u2);
+        let members = client.get_role_members(&role);
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&u1));
+        assert!(members.contains(&u2));
+
+        client.revoke_role(&admin, &role, &u1);
+        let members = client.get_role_members(&role);
+        assert_eq!(members.len(), 1);
+        assert!(members.contains(&u2));
+    }
+
+    #[test]
+    fn test_get_roles_for_address() {
+        let (env, admin, client) = setup();
+        let r1 = String::from_str(&env, "operator");
+        let r2 = String::from_str(&env, "auditor");
+        let user = Address::generate(&env);
+
+        assert!(client.get_roles_for_address(&user).is_empty());
+
+        client.grant_role(&admin, &r1, &user);
+        client.grant_role(&admin, &r2, &user);
+        let roles = client.get_roles_for_address(&user);
+        assert_eq!(roles.len(), 2);
+        assert!(roles.contains(&r1));
+        assert!(roles.contains(&r2));
+
+        client.revoke_role(&admin, &r1, &user);
+        let roles = client.get_roles_for_address(&user);
+        assert_eq!(roles.len(), 1);
+        assert!(roles.contains(&r2));
     }
 }

--- a/contracts/router-access/test_snapshots/tests/test_blacklist_prevents_grant.1.json
+++ b/contracts/router-access/test_snapshots/tests/test_blacklist_prevents_grant.1.json
@@ -240,6 +240,26 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "address_blacklisted"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {

--- a/contracts/router-access/test_snapshots/tests/test_double_grant_fails.1.json
+++ b/contracts/router-access/test_snapshots/tests/test_double_grant_fails.1.json
@@ -69,6 +69,25 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "AddressRoles"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "string": "operator"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "HasRole"
                             },
                             {
@@ -81,6 +100,25 @@
                         },
                         "val": {
                           "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RoleMembers"
+                            },
+                            {
+                              "string": "operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
                         }
                       },
                       {
@@ -232,6 +270,33 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
+                {
+                  "string": "operator"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "role_granted"
+              }
+            ],
+            "data": {
+              "vec": [
                 {
                   "string": "operator"
                 },

--- a/contracts/router-access/test_snapshots/tests/test_grant_and_check_role.1.json
+++ b/contracts/router-access/test_snapshots/tests/test_grant_and_check_role.1.json
@@ -69,6 +69,25 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "AddressRoles"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "string": "operator"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "HasRole"
                             },
                             {
@@ -81,6 +100,25 @@
                         },
                         "val": {
                           "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RoleMembers"
+                            },
+                            {
+                              "string": "operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
                         }
                       },
                       {
@@ -232,6 +270,33 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
+                {
+                  "string": "operator"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "role_granted"
+              }
+            ],
+            "data": {
+              "vec": [
                 {
                   "string": "operator"
                 },

--- a/contracts/router-access/test_snapshots/tests/test_revoke_role.1.json
+++ b/contracts/router-access/test_snapshots/tests/test_revoke_role.1.json
@@ -94,10 +94,7 @@
                         "key": {
                           "vec": [
                             {
-                              "symbol": "HasRole"
-                            },
-                            {
-                              "string": "operator"
+                              "symbol": "AddressRoles"
                             },
                             {
                               "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -105,7 +102,22 @@
                           ]
                         },
                         "val": {
-                          "bool": false
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RoleMembers"
+                            },
+                            {
+                              "string": "operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
                         }
                       },
                       {
@@ -307,6 +319,33 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "role_granted"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "operator"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -347,6 +386,33 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
+                {
+                  "string": "operator"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "role_revoked"
+              }
+            ],
+            "data": {
+              "vec": [
                 {
                   "string": "operator"
                 },

--- a/contracts/router-access/test_snapshots/tests/test_role_admin_can_grant.1.json
+++ b/contracts/router-access/test_snapshots/tests/test_role_admin_can_grant.1.json
@@ -94,6 +94,25 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "AddressRoles"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "string": "operator"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "HasRole"
                             },
                             {
@@ -121,6 +140,25 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "RoleMembers"
+                            },
+                            {
+                              "string": "operator"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          ]
                         }
                       },
                       {
@@ -362,6 +400,33 @@
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
+                {
+                  "string": "operator"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "role_granted"
+              }
+            ],
+            "data": {
+              "vec": [
                 {
                   "string": "operator"
                 },

--- a/contracts/router-access/test_snapshots/tests/test_transfer_super_admin.1.json
+++ b/contracts/router-access/test_snapshots/tests/test_transfer_super_admin.1.json
@@ -225,6 +225,33 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "admin_transferred"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -51,6 +51,7 @@ pub enum RegistryError {
     AlreadyRegistered = 5,
     AlreadyDeprecated = 6,
     InvalidVersion = 7,
+    VersionNotFound = 8,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -228,12 +229,15 @@ impl RouterRegistry {
     ) -> Result<(), RegistryError> {
         caller.require_auth();
         Self::require_admin(&env, &caller)?;
+        Self::deprecate_one(&env, name, version)
+    }
 
+    fn deprecate_one(env: &Env, name: String, version: u32) -> Result<(), RegistryError> {
         let mut entry: ContractEntry = env
             .storage()
             .instance()
             .get(&DataKey::Entry(name.clone(), version))
-            .ok_or(RegistryError::NotFound)?;
+            .ok_or(RegistryError::VersionNotFound)?;
 
         if entry.deprecated {
             return Err(RegistryError::AlreadyDeprecated);
@@ -242,6 +246,25 @@ impl RouterRegistry {
         entry.deprecated = true;
         env.storage().instance().set(&DataKey::Entry(name, version), &entry);
         Ok(())
+    }
+
+    pub fn deprecate_many(
+        env: Env,
+        caller: Address,
+        entries: Vec<(String, u32)>,
+    ) -> Vec<Result<(), RegistryError>> {
+        caller.require_auth();
+        let mut results = Vec::new(&env);
+        if Self::require_admin(&env, &caller).is_err() {
+            for _ in entries.iter() {
+                results.push_back(Err(RegistryError::Unauthorized));
+            }
+            return results;
+        }
+        for (name, version) in entries.iter() {
+            results.push_back(Self::deprecate_one(&env, name, version));
+        }
+        results
     }
 
     /// Transfer admin to a new address.
@@ -332,7 +355,7 @@ impl RouterRegistry {
 mod tests {
     extern crate std;
     use super::*;
-    use soroban_sdk::{testutils::{Address as _, Events}, vec, Env, IntoVal, String, Val};
+    use soroban_sdk::{testutils::{Address as _, Events}, vec, Env, IntoVal, String};
 
     fn setup() -> (Env, Address, RouterRegistryClient<'static>) {
         let env = Env::default();
@@ -399,6 +422,16 @@ mod tests {
         // latest should now return v1
         let latest = client.get_latest(&name);
         assert_eq!(latest.version, 1);
+    }
+
+    #[test]
+    fn test_deprecate_nonexistent_version_returns_error() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register(&admin, &name, &addr, &1);
+        let result = client.try_deprecate(&admin, &name, &99);
+        assert_eq!(result, Err(Ok(RegistryError::VersionNotFound)));
     }
 
     #[test]
@@ -485,8 +518,9 @@ mod tests {
             event.1,
             vec![&env, Symbol::new(&env, "admin_transferred").into_val(&env)]
         );
-        let expected_data: Val = (admin, new_admin).into_val(&env);
-        assert_eq!(event.2, expected_data);
+        let (old, new): (Address, Address) = event.2.into_val(&env);
+        assert_eq!(old, admin);
+        assert_eq!(new, new_admin);
     }
 
     #[test]
@@ -532,5 +566,44 @@ mod tests {
         let name = String::from_str(&env, "nonexistent");
         let versions = client.versions(&name);
         assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn test_deprecate_many_all_succeed() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let (a1, a2, a3) = (Address::generate(&env), Address::generate(&env), Address::generate(&env));
+        client.register(&admin, &name, &a1, &1);
+        client.register(&admin, &name, &a2, &2);
+        client.register(&admin, &name, &a3, &3);
+
+        let entries = vec![&env,
+            (name.clone(), 1u32),
+            (name.clone(), 2u32),
+            (name.clone(), 3u32),
+        ];
+        let results = client.deprecate_many(&admin, &entries);
+        assert_eq!(results.len(), 3);
+        for r in results.iter() {
+            assert_eq!(r, Ok(()));
+        }
+    }
+
+    #[test]
+    fn test_deprecate_many_partial_errors() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register(&admin, &name, &addr, &1);
+
+        let entries = vec![&env,
+            (name.clone(), 1u32),  // ok
+            (name.clone(), 99u32), // VersionNotFound
+            (name.clone(), 1u32),  // AlreadyDeprecated
+        ];
+        let results = client.deprecate_many(&admin, &entries);
+        assert_eq!(results.get(0).unwrap(), Ok(()));
+        assert_eq!(results.get(1).unwrap(), Err(RegistryError::VersionNotFound));
+        assert_eq!(results.get(2).unwrap(), Err(RegistryError::AlreadyDeprecated));
     }
 }

--- a/contracts/router-registry/test_snapshots/tests/test_transfer_admin.1.json
+++ b/contracts/router-registry/test_snapshots/tests/test_transfer_admin.1.json
@@ -225,6 +225,33 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "admin_transferred"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {


### PR DESCRIPTION
… (#93)

- Add VersionNotFound = 8 to RegistryError
- deprecate() uses VersionNotFound instead of generic NotFound
- Add deprecate_many() for bulk deprecation with per-entry results (#95)
- Extract deprecate_one() private helper to avoid re-auth in batch path
- Fix pre-existing Val PartialEq compile error in test_transfer_admin_emits_event

feat(access): add get_role_members and get_roles_for_address (#97)

- Add RoleMembers(String) and AddressRoles(Address) storage indexes
- grant_role/revoke_role maintain both indexes on every mutation
- Add get_role_members() and get_roles_for_address() query functions
- Fix pre-existing Val PartialEq compile errors across access tests
Closes #93 
Closes #94 
Closes #95 
Closes #97 