### PR TITLE
Emit RouteOverwritten event on update_route

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -144,7 +144,9 @@ impl RouterCore {
     /// Update an existing route to point to a new address.
     ///
     /// Replaces the contract address for an existing route. The route must
-    /// already exist. Caller must be the admin.
+    /// already exist. Caller must be the admin. Emits both a `route_updated`
+    /// event and a `route_overwritten` event carrying the old and new addresses
+    /// so that off-chain observers can detect unintended redirections.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment.
@@ -174,13 +176,19 @@ impl RouterCore {
             .get(&DataKey::Route(name.clone()))
             .ok_or(RouterError::RouteNotFound)?;
 
-        entry.address = new_address;
+        let old_address = entry.address.clone();
+        entry.address = new_address.clone();
         entry.updated_by = caller;
         env.storage().instance().set(&DataKey::Route(name.clone()), &entry);
 
         env.events().publish(
             (Symbol::new(&env, "route_updated"),),
             name.clone(),
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "route_overwritten"),),
+            (name.clone(), old_address, new_address),
         );
 
         Ok(())
@@ -697,6 +705,32 @@ mod tests {
         assert_eq!(client.try_resolve(&name), Err(Ok(RouterError::RouterPaused)));
         client.set_paused(&admin, &false);
         assert_eq!(client.resolve(&name), addr);
+    }
+
+    #[test]
+    fn test_update_route_emits_overwritten_event() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr1 = Address::generate(&env);
+        let addr2 = Address::generate(&env);
+        client.register_route(&admin, &name, &addr1);
+
+        let events_before = env.events().all().len();
+        client.update_route(&admin, &name, &addr2);
+        let events_after = env.events().all().len();
+
+        // Two events: route_updated + route_overwritten
+        assert_eq!(events_after, events_before + 2);
+
+        // Verify route_overwritten event carries old and new addresses
+        let overwrite_event = env.events().all().last().unwrap().clone();
+        assert_eq!(overwrite_event.0, client.address);
+        assert_eq!(
+            overwrite_event.1,
+            vec![&env, Symbol::new(&env, "route_overwritten").into_val(&env)]
+        );
+        let expected_data: Val = (name, addr1, addr2).into_val(&env);
+        assert_eq!(overwrite_event.2, expected_data);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When `update_route` was called, only a generic `route_updated` event was
emitted. There was no way for off-chain observers to distinguish a routine update from an unintended redirect, and no record of what the previous address was.

this pr Closes #105 

## Changes

- `update_route` now captures the old address before overwriting
- Emits a new `route_overwritten` event with payload `(name, old_address, new_address)`
- Added `test_update_route_emits_overwritten_event` to verify both events
  fire and the overwritten event carries the correct addresses

## Event payload

| Field         | Type      | Description                        |
|---------------|-----------|------------------------------------|
| `name`        | `String`  | The route name that was redirected |
| `old_address` | `Address` | The address before the update      |
| `new_address` | `Address` | The address after the update       |

## Notes

`register_route` was not changed — it already returns `RouteAlreadyExists`
and never silently replaces an existing route.

Closes #<issue-number>
