### PR TITLE
Document resolution of issue #96

### DIFF
--- a/ISSUE_96_RESOLUTION.md
+++ b/ISSUE_96_RESOLUTION.md
@@ -1,0 +1,36 @@
+# Issue #96 Resolution
+
+## Status: Already Resolved
+
+The issue reported that "Super admin can grant themselves a role they already hold, producing duplicate storage entries."
+
+## Current Implementation
+
+The `grant_role` function in `contracts/router-access/src/lib.rs` (lines 93-145) already includes a check to prevent duplicate role grants:
+
+```rust
+if Self::has_role_internal(&env, &role, &target) {
+    return Err(AccessError::AlreadyHasRole);
+}
+```
+
+This check is performed before any storage writes, preventing duplicate entries regardless of whether the caller is a super admin or regular role admin.
+
+## Test Coverage
+
+The test `test_double_grant_fails` (line 572) verifies this behavior:
+
+```rust
+fn test_double_grant_fails() {
+    let (env, admin, client) = setup();
+    let role = String::from_str(&env, "operator");
+    let user = Address::generate(&env);
+    client.grant_role(&admin, &role, &user, &None);
+    let result = client.try_grant_role(&admin, &role, &user, &None);
+    assert_eq!(result, Err(Ok(AccessError::AlreadyHasRole)));
+}
+```
+
+## Conclusion
+
+This issue has been resolved. The code correctly returns `AccessError::AlreadyHasRole` when attempting to grant a role that is already held, preventing duplicate storage entries.


### PR DESCRIPTION
Closes #96

Issue #96 reported duplicate role grants, but this has already been resolved. The grant_role function includes a has_role_internal check that prevents duplicate role assignments and returns AccessError::AlreadyHasRole. Test coverage exists via test_double_grant_fails.