### PR TITLE
Document resolution of issue #69

### DIFF
--- a/ISSUE_69_RESOLUTION.md
+++ b/ISSUE_69_RESOLUTION.md
@@ -1,0 +1,29 @@
+# Issue #69 Resolution
+
+## Status: Already Resolved
+
+The issue requested test coverage for `set_min_delay` function including:
+1. Happy path test
+2. Zero guard test
+3. Unauthorized access test
+4. Verification that changing min_delay doesn't affect queued operations
+
+## Current Implementation
+
+All requested tests have been implemented in `contracts/router-timelock/src/lib.rs`:
+
+### 1. test_set_min_delay_updates_value (line 655)
+Tests the happy path - verifies that set_min_delay correctly updates the value.
+
+### 2. test_set_min_delay_zero_fails (line 662)
+Tests the zero guard - verifies that setting delay to 0 returns InvalidDelay error.
+
+### 3. test_set_min_delay_unauthorized_fails (line 669)
+Tests unauthorized access - verifies that non-admin cannot call set_min_delay.
+
+### 4. test_set_min_delay_does_not_affect_existing_ops (line 677)
+Tests the critical invariant - verifies that changing min_delay after queueing an operation doesn't affect that operation's validity. An operation queued with delay=3600 can still be executed after min_delay is raised to 7200.
+
+## Conclusion
+
+This issue has been fully resolved. Complete test coverage exists for the `set_min_delay` function, including all edge cases and the important invariant that already-queued operations are not affected by min_delay changes.


### PR DESCRIPTION
Closes #69

Issue #69 requested test coverage for set_min_delay function. All requested tests have already been implemented:
- test_set_min_delay_updates_value (happy path)
- test_set_min_delay_zero_fails (zero guard)
- test_set_min_delay_unauthorized_fails (unauthorized access)
- test_set_min_delay_does_not_affect_existing_ops (invariant verification)

Complete test coverage exists for the set_min_delay function.