### PR TITLE
fix: emit events and add getters (#149, #150, #153, #155)

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -169,8 +169,10 @@ impl RouterCore {
             .instance()
             .set(&DataKey::RouteNames, &route_names);
 
-        env.events()
-            .publish((Symbol::new(&env, "route_registered"),), name.clone());
+        env.events().publish(
+            (Symbol::new(&env, "route_registered"),),
+            (name.clone(), entry.address.clone()),
+        );
 
         Ok(())
     }
@@ -749,6 +751,20 @@ mod tests {
         let resolved = client.resolve(&name);
         assert_eq!(resolved, addr);
         assert_eq!(client.total_routed(), 1);
+
+        // Verify route_registered event carries both name and address
+        let events = env.events().all();
+        let reg_event = events.iter().find(|e| {
+            e.1.get(0)
+                .map(|v| {
+                    let s: Symbol = v.into_val(&env);
+                    s == Symbol::new(&env, "route_registered")
+                })
+                .unwrap_or(false)
+        }).unwrap();
+        let (emitted_name, emitted_addr): (String, Address) = reg_event.2.into_val(&env);
+        assert_eq!(emitted_name, name);
+        assert_eq!(emitted_addr, addr);
     }
 
     #[test]

--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -24,6 +24,7 @@ pub enum DataKey {
     TotalCalls,
     CircuitBreaker(String),     // route_name -> CircuitBreakerState
     CallLog(String),            // route_name -> Vec<CallLogEntry>
+    ConfiguredRoutes,           // Vec<String>
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -172,7 +173,16 @@ impl RouterMiddleware {
             recovery_window_seconds,
             log_retention,
         };
-        env.storage().instance().set(&DataKey::RouteConfig(route), &config);
+        env.storage().instance().set(&DataKey::RouteConfig(route.clone()), &config);
+
+        let mut configured: Vec<String> = env.storage().instance()
+            .get(&DataKey::ConfiguredRoutes)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !configured.contains(&route) {
+            configured.push_back(route.clone());
+            env.storage().instance().set(&DataKey::ConfiguredRoutes, &configured);
+        }
+
         Ok(())
     }
 
@@ -518,6 +528,34 @@ impl RouterMiddleware {
     /// `Some(`[`RouteConfig`]`)` if a config exists for `route`, `None` otherwise.
     pub fn route_config(env: Env, route: String) -> Option<RouteConfig> {
         env.storage().instance().get(&DataKey::RouteConfig(route))
+    }
+
+    /// Returns all route names that have been configured via configure_route.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    ///
+    /// # Returns
+    /// A `Vec<String>` of unique route names passed to `configure_route`.
+    pub fn get_configured_routes(env: Env) -> Vec<String> {
+        env.storage().instance()
+            .get(&DataKey::ConfiguredRoutes)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Get the current circuit breaker state for a route.
+    ///
+    /// Returns `None` if no circuit breaker state has been recorded for the route
+    /// (i.e. no failures have occurred since initialization or last reset).
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `route` - The route name to query.
+    ///
+    /// # Returns
+    /// `Some(CircuitBreakerState)` if state exists, `None` otherwise.
+    pub fn circuit_breaker_state(env: Env, route: String) -> Option<CircuitBreakerState> {
+        env.storage().instance().get(&DataKey::CircuitBreaker(route))
     }
 
     /// Get current admin.
@@ -958,5 +996,85 @@ mod tests {
             client.try_pre_call(&caller, &route),
             Err(Ok(MiddlewareError::CircuitOpen))
         );
+    }
+
+    // ── Issue #150: get_configured_routes ────────────────────────────────────
+
+    #[test]
+    fn test_get_configured_routes_empty() {
+        let (_env, _admin, client) = setup();
+        let routes = client.get_configured_routes();
+        assert!(routes.is_empty());
+    }
+
+    #[test]
+    fn test_get_configured_routes_multiple() {
+        let (env, admin, client) = setup();
+        let route_a = String::from_str(&env, "oracle/price");
+        let route_b = String::from_str(&env, "vault/deposit");
+        client.configure_route(&admin, &route_a, &0, &0, &true, &0, &0, &0);
+        client.configure_route(&admin, &route_b, &0, &0, &true, &0, &0, &0);
+        let routes = client.get_configured_routes();
+        assert_eq!(routes.len(), 2);
+        assert!(routes.contains(&route_a));
+        assert!(routes.contains(&route_b));
+    }
+
+    #[test]
+    fn test_get_configured_routes_no_duplicates() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/price");
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        let routes = client.get_configured_routes();
+        assert_eq!(routes.len(), 1);
+    }
+
+    // ── Issue #155: circuit_breaker_state getter ──────────────────────────────
+
+    #[test]
+    fn test_circuit_breaker_state_none_before_failures() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0);
+        assert_eq!(client.circuit_breaker_state(&route), None);
+    }
+
+    #[test]
+    fn test_circuit_breaker_state_reflects_failures() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0);
+        let caller = Address::generate(&env);
+        client.post_call(&caller, &route, &false);
+        let state = client.circuit_breaker_state(&route).unwrap();
+        assert_eq!(state.failure_count, 1);
+        assert!(!state.is_open);
+    }
+
+    #[test]
+    fn test_circuit_breaker_state_open_after_threshold() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &0, &0, &true, &2, &0, &0);
+        let caller = Address::generate(&env);
+        client.post_call(&caller, &route, &false);
+        client.post_call(&caller, &route, &false);
+        let state = client.circuit_breaker_state(&route).unwrap();
+        assert!(state.is_open);
+        assert!(state.opened_at > 0);
+    }
+
+    #[test]
+    fn test_circuit_breaker_state_clears_after_reset() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0);
+        let caller = Address::generate(&env);
+        client.post_call(&caller, &route, &false);
+        assert!(client.circuit_breaker_state(&route).unwrap().is_open);
+        client.reset_circuit_breaker(&admin, &route);
+        let state = client.circuit_breaker_state(&route).unwrap();
+        assert!(!state.is_open);
     }
 }

--- a/contracts/router-multicall/src/lib.rs
+++ b/contracts/router-multicall/src/lib.rs
@@ -256,7 +256,14 @@ impl RouterMulticall {
         if max_batch_size == 0 {
             return Err(MulticallError::InvalidConfig);
         }
+        let old_max: u32 = env.storage().instance()
+            .get(&DataKey::MaxBatchSize)
+            .unwrap_or(0);
         env.storage().instance().set(&DataKey::MaxBatchSize, &max_batch_size);
+        env.events().publish(
+            (Symbol::new(&env, "max_batch_size_updated"),),
+            (old_max, max_batch_size),
+        );
         Ok(())
     }
 
@@ -410,6 +417,20 @@ mod tests {
         let (_env, admin, client) = setup();
         client.set_max_batch_size(&admin, &5);
         assert_eq!(client.max_batch_size(), 5);
+    }
+
+    #[test]
+    fn test_set_max_batch_size_emits_event() {
+        let (env, admin, client) = setup();
+        // initial max is 10 (from setup)
+        client.set_max_batch_size(&admin, &5);
+        let events = env.events().all();
+        let last = events.last().unwrap();
+        let topic: Symbol = last.1.get(0).unwrap().into_val(&env);
+        assert_eq!(topic, Symbol::new(&env, "max_batch_size_updated"));
+        let (old, new): (u32, u32) = last.2.into_val(&env);
+        assert_eq!(old, 10);
+        assert_eq!(new, 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes four issues in a single commit.

### #153 — `register_route` event omits the registered address (router-core)
Changed the `route_registered` event data from `name` to `(name, address)` to match the pattern of `route_overwritten`. Updated `test_register_and_resolve` to assert both fields.

### #149 — emit event from `set_max_batch_size` (router-multicall)
Captures the old value before writing, then emits `max_batch_size_updated` with `(old, new)`. Added `test_set_max_batch_size_emits_event`.

### #150 — add `get_configured_routes` (router-middleware)
Added `ConfiguredRoutes` to `DataKey`, maintains the list (no duplicates) inside `configure_route`, and exposes a `get_configured_routes` getter. Added three tests: empty, multiple, no-duplicates.

### #155 — add `circuit_breaker_state` getter (router-middleware)
Added a public read-only `circuit_breaker_state(env, route) -> Option<CircuitBreakerState>` mirroring `rate_limit_state`. Added four tests covering: none before failures, reflects failures, open after threshold, clears after reset.

Closes #149, Closes #150, Closes  #153, Closes #155