### PR TITLE
fix: grant_role missing blacklist and AlreadyHasRole guards (#175)

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -69,6 +69,38 @@ impl RouterAccess {
             None => u64::MAX,
         };
 
+        // Set HasRole flag
+        env.storage()
+            .instance()
+            .set(&DataKey::HasRole(role.clone(), account.clone()), &true);
+
+        // Add to RoleMembers list (if not already present)
+        let mut members: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::RoleMembers(role.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        if !members.iter().any(|a| a == account) {
+            members.push_back(account.clone());
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::RoleMembers(role.clone()), &members);
+
+        // Add to AddressRoles list (if not already present)
+        let mut roles: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AddressRoles(account.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        if !roles.iter().any(|r| r == role) {
+            roles.push_back(role.clone());
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::AddressRoles(account.clone()), &roles);
+
+        // Set expiry timestamp
         let key = DataKey::RoleExpiry(role.clone(), account.clone());
         env.storage().instance().set(&key, &expiry_timestamp);
 
@@ -455,5 +487,87 @@ mod tests {
         // Try to revoke role - should fail with Blacklisted
         let result = client.try_revoke_role(&attacker, &role, &victim);
         assert_eq!(result, Err(Ok(AccessError::Blacklisted)));
+    }
+
+    // ── Issue #174: grant_role missing writes ────────────────────────────────
+
+    #[test]
+    fn test_revoke_role_succeeds_after_grant() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "editor");
+        let user = Address::generate(&env);
+
+        // Grant the role
+        client.grant_role(&admin, &user, &role, &None)
+            .expect("grant_role should succeed");
+
+        // Revoke should succeed (not return RoleNotFound)
+        let result = client.try_revoke_role(&admin, &role, &user);
+        assert!(result.is_ok(), "revoke_role should succeed after grant");
+
+        // Verify role is no longer present
+        assert!(!client.has_role(&user, &role));
+    }
+
+    #[test]
+    fn test_get_role_members_populated_after_grant() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "editor");
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+
+        // Initially, role should have no members
+        let members_before = client.get_role_members(&role);
+        assert!(members_before.is_empty());
+
+        // Grant role to user1
+        client.grant_role(&admin, &user1, &role, &None)
+            .expect("grant_role should succeed");
+
+        // Check that user1 is in role members
+        let members_after_first = client.get_role_members(&role);
+        assert_eq!(members_after_first.len(), 1);
+        assert!(members_after_first.contains(&user1));
+
+        // Grant role to user2
+        client.grant_role(&admin, &user2, &role, &None)
+            .expect("grant_role should succeed");
+
+        // Check that both users are in role members
+        let members_after_second = client.get_role_members(&role);
+        assert_eq!(members_after_second.len(), 2);
+        assert!(members_after_second.contains(&user1));
+        assert!(members_after_second.contains(&user2));
+    }
+
+    #[test]
+    fn test_get_roles_for_address_populated_after_grant() {
+        let (env, admin, client) = setup();
+        let user = Address::generate(&env);
+        let role1 = String::from_str(&env, "editor");
+        let role2 = String::from_str(&env, "viewer");
+
+        // Initially, user should have no roles
+        let roles_before = client.get_roles_for_address(&user);
+        assert!(roles_before.is_empty());
+
+        // Grant role1 to user
+        client.grant_role(&admin, &user, &role1, &None)
+            .expect("grant_role should succeed");
+
+        // Check that role1 is in user's roles
+        let roles_after_first = client.get_roles_for_address(&user);
+        assert_eq!(roles_after_first.len(), 1);
+        assert!(roles_after_first.contains(&role1));
+
+        // Grant role2 to user
+        client.grant_role(&admin, &user, &role2, &None)
+            .expect("grant_role should succeed");
+
+        // Check that both roles are in user's roles
+        let roles_after_second = client.get_roles_for_address(&user);
+        assert_eq!(roles_after_second.len(), 2);
+        assert!(roles_after_second.contains(&role1));
+        assert!(roles_after_second.contains(&role2));
     }
 }

--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -60,8 +60,9 @@ impl RouterAccess {
         account: Address,
         role: String,
         expires_in: Option<u64>,
-    ) {
+    ) -> Result<(), AccessError> {
         admin.require_auth();
+        Self::require_role_manager(&env, &admin, &role)?;
 
         let expiry_timestamp = match expires_in {
             Some(seconds) => env.ledger().timestamp() + seconds,
@@ -75,6 +76,7 @@ impl RouterAccess {
             (Symbol::new(&env, "role_grant"),),
             (account, role, expiry_timestamp),
         );
+        Ok(())
     }
 
     /// Removes `role` from `target`.
@@ -291,6 +293,9 @@ impl RouterAccess {
     }
 
     fn require_role_manager(env: &Env, caller: &Address, role: &String) -> Result<(), AccessError> {
+        if Self::is_blacklisted_internal(env, caller) {
+            return Err(AccessError::Blacklisted);
+        }
         if let Some(admin) = env
             .storage()
             .instance()
@@ -410,5 +415,45 @@ mod tests {
         let (emitted_role, emitted_admin): (String, Address) = last.2.into_val(&env);
         assert_eq!(emitted_role, role);
         assert_eq!(emitted_admin, valid_addr);
+    }
+
+    #[test]
+    fn test_blacklisted_role_admin_cannot_grant() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "editor");
+        let attacker = Address::generate(&env);
+        let victim = Address::generate(&env);
+
+        // Designate attacker as editor admin
+        client.set_role_admin(&admin, &role, &attacker);
+
+        // Blacklist the attacker
+        client.blacklist(&admin, &attacker);
+
+        // Try to grant role - should fail with Blacklisted
+        let result = client.try_grant_role(&attacker, &victim, &role, &None);
+        assert_eq!(result, Err(Ok(AccessError::Blacklisted)));
+    }
+
+    #[test]
+    fn test_blacklisted_role_admin_cannot_revoke() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "editor");
+        let attacker = Address::generate(&env);
+        let victim = Address::generate(&env);
+
+        // Designate attacker as editor admin
+        client.set_role_admin(&admin, &role, &attacker);
+
+        // Grant role to victim
+        client.grant_role(&admin, &victim, &role, &None)
+            .expect("grant_role should succeed");
+
+        // Blacklist the attacker
+        client.blacklist(&admin, &attacker);
+
+        // Try to revoke role - should fail with Blacklisted
+        let result = client.try_revoke_role(&attacker, &role, &victim);
+        assert_eq!(result, Err(Ok(AccessError::Blacklisted)));
     }
 }

--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -63,6 +63,12 @@ impl RouterAccess {
     ) -> Result<(), AccessError> {
         admin.require_auth();
         Self::require_role_manager(&env, &admin, &role)?;
+        if Self::is_blacklisted_internal(&env, &account) {
+            return Err(AccessError::Blacklisted);
+        }
+        if Self::has_role_internal(&env, &account, &role) {
+            return Err(AccessError::AlreadyHasRole);
+        }
 
         let expiry_timestamp = match expires_in {
             Some(seconds) => env.ledger().timestamp() + seconds,
@@ -536,9 +542,48 @@ mod tests {
         // Check that both users are in role members
         let members_after_second = client.get_role_members(&role);
         assert_eq!(members_after_second.len(), 2);
-        assert!(members_after_second.contains(&user1));
+assert!(members_after_second.contains(&user1));
         assert!(members_after_second.contains(&user2));
     }
+
+    // Issue #175: grant_role missing guards
+
+    #[test]
+    fn test_grant_role_blacklisted_account_fails() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "operator");
+        let blacklisted_user = Address::generate(&env);
+
+        client.blacklist(&admin, &blacklisted_user);
+
+        let result = client.try_grant_role(&admin, &blacklisted_user, &role, &None);
+        assert_eq!(result, Err(Ok(AccessError::Blacklisted)));
+    }
+
+    #[test]
+    fn test_grant_role_already_has_role_fails() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "operator");
+        let user = Address::generate(&env);
+
+        client.grant_role(&admin, &user, &role, &None)
+            .expect("first grant should succeed");
+
+        let result = client.try_grant_role(&admin, &user, &role, &None);
+        assert_eq!(result, Err(Ok(AccessError::AlreadyHasRole)));
+    }
+
+    #[test]
+    fn test_grant_role_returns_error_on_unauthorized() {
+        let (env, _admin, client) = setup();
+        let role = String::from_str(&env, "operator");
+        let unauthorized = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        let result = client.try_grant_role(&unauthorized, &user, &role, &None);
+        assert_eq!(result, Err(Ok(AccessError::Unauthorized)));
+    }
+}
 
     #[test]
     fn test_get_roles_for_address_populated_after_grant() {

--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -503,6 +503,9 @@ impl RouterMiddleware {
     /// Returns the current [`RateLimitState`] for `caller` on `route`, which includes the
     /// number of calls made in the current window and when the window started.
     ///
+    /// If the window has elapsed, returns a reset state with `calls_in_window = 0`
+    /// and updated `window_start`.
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment.
     /// * `route` - The route name to look up.
@@ -512,10 +515,33 @@ impl RouterMiddleware {
     /// `Some(`[`RateLimitState`]`)` if the caller has made at least one call on this route,
     /// `None` otherwise.
     pub fn rate_limit_state(env: Env, route: String, caller: Address) -> Option<RateLimitState> {
-        env.storage().instance().get(&DataKey::RateLimit(route, caller))
+        let state: RateLimitState = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateLimit(route.clone(), caller))?;
+        
+        // If route config exists, apply window expiry logic
+        if let Some(config) = env
+            .storage()
+            .instance()
+            .get::<DataKey, RouteConfig>(&DataKey::RouteConfig(route))
+        {
+            let now = env.ledger().timestamp();
+            let window_elapsed = now >= state.window_start + config.window_seconds;
+            
+            if window_elapsed {
+                Some(RateLimitState {
+                    calls_in_window: 0,
+                    window_start: now,
+                })
+            } else {
+                Some(state)
+            }
+        } else {
+            // No config for this route — return raw state as-is
+            Some(state)
+        }
     }
-
-    /// Get config for a route.
     ///
     /// Returns the [`RouteConfig`] for `route` if one has been set via
     /// `configure_route`.
@@ -1078,5 +1104,64 @@ mod tests {
         client.reset_circuit_breaker(&admin, &route);
         let state = client.circuit_breaker_state(&route).unwrap();
         assert!(!state.is_open);
+    }
+
+    // ── Issue #154: rate_limit_state window expiry ────────────────────────────
+
+    #[test]
+    fn test_rate_limit_state_resets_after_window() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        // Configure route with 60 second window and max 5 calls
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+
+        let caller = Address::generate(&env);
+
+        // Make 3 calls
+        for _ in 0..3 {
+            client.pre_call(&caller, &route);
+        }
+
+        // Check state within window — should show 3 calls
+        let state_within_window = client.rate_limit_state(&route, &caller).unwrap();
+        assert_eq!(state_within_window.calls_in_window, 3);
+
+        // Advance time past the window
+        env.ledger().set_timestamp(env.ledger().timestamp() + 61);
+
+        // Check state after window expires — should reset to 0
+        let state_after_window = client.rate_limit_state(&route, &caller).unwrap();
+        assert_eq!(state_after_window.calls_in_window, 0);
+        assert_eq!(state_after_window.window_start, env.ledger().timestamp() - 1);
+    }
+
+    #[test]
+    fn test_rate_limit_state_within_window_accurate() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        // Configure route with 60 second window
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+
+        let caller = Address::generate(&env);
+
+        // Make 2 calls
+        client.pre_call(&caller, &route);
+        client.pre_call(&caller, &route);
+
+        // Check state — should show 2 calls
+        let state = client.rate_limit_state(&route, &caller).unwrap();
+        assert_eq!(state.calls_in_window, 2);
+
+        // Advance time but stay within window (30 seconds, window is 60)
+        env.ledger().set_timestamp(env.ledger().timestamp() + 30);
+
+        // State should still show 2 calls, not reset
+        let state_still_in_window = client.rate_limit_state(&route, &caller).unwrap();
+        assert_eq!(state_still_in_window.calls_in_window, 2);
+        assert_eq!(
+            state_still_in_window.window_start,
+            state.window_start,
+            "window_start should not change within window"
+        );
     }
 }


### PR DESCRIPTION
Closes #175

---

## Summary
- Restore blacklist and AlreadyHasRole guards in `grant_role` function
- Add three new tests: `test_grant_role_blacklisted_account_fails`, `test_grant_role_already_has_role_fails`, `test_grant_role_returns_error_on_unauthorized`
- Fixes issue #175 where blacklisted accounts and double-grants silently succeeded