### PR TITLE
fix(router-timelock): guard execute_critical behind FastTrackEnabled …

### DIFF
--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -387,6 +387,15 @@ impl RouterTimelock {
         caller.require_auth();
         Self::require_admin(&env, &caller)?;
 
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::FastTrackEnabled)
+            .unwrap_or(false);
+        if !enabled {
+            return Err(TimelockError::FastTrackDisabled);
+        }
+
         let mut op: TimelockOp = env
             .storage()
             .instance()
@@ -1331,6 +1340,40 @@ mod tests {
             client.try_queue_critical(&admin, &desc, &target, &3600),
             Err(Ok(TimelockError::FastTrackDisabled))
         );
+    }
+
+    #[test]
+    fn test_execute_critical_fails_when_fast_track_disabled() {
+        let (env, admin, client, m1, m2, _) = setup_with_council();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "critical fix");
+        // Queue and fully approve while fast-track is still enabled
+        let op_id = client.queue_critical(&admin, &desc, &target, &3600);
+        client.approve_critical(&m1, &op_id);
+        client.approve_critical(&m2, &op_id);
+
+        // Admin disables fast-track (e.g. council member compromised)
+        client.set_fast_track_enabled(&admin, &false);
+
+        // execute_critical must now be blocked
+        assert_eq!(
+            client.try_execute_critical(&admin, &op_id),
+            Err(Ok(TimelockError::FastTrackDisabled))
+        );
+    }
+
+    #[test]
+    fn test_execute_critical_succeeds_when_enabled() {
+        let (env, admin, client, m1, m2, _) = setup_with_council();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "critical fix");
+        let op_id = client.queue_critical(&admin, &desc, &target, &3600);
+        client.approve_critical(&m1, &op_id);
+        client.approve_critical(&m2, &op_id);
+
+        // Fast-track is enabled by default — execution should succeed
+        assert!(client.try_execute_critical(&admin, &op_id).is_ok());
+        assert!(client.get_op(&op_id).unwrap().executed);
     }
 
     #[test]


### PR DESCRIPTION
pr closes #177 

## Summary

`execute_critical` was missing the `FastTrackEnabled` guard that
`queue_critical` already enforces. An admin disabling fast-track after
approvals were collected (e.g. following a council member compromise)
could not prevent execution of already-approved ops, defeating the
purpose of `set_fast_track_enabled`.

## Root Cause

`queue_critical` correctly checks:
```rust
let enabled: bool = env.storage().instance()
    .get(&DataKey::FastTrackEnabled).unwrap_or(false);
if !enabled { return Err(TimelockError::FastTrackDisabled); }
