### PR TITLE
fix(access): remove RoleExpiry key on revoke_role

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -159,6 +159,10 @@ impl RouterAccess {
             .instance()
             .set(&DataKey::AddressRoles(target.clone()), &roles);
 
+        env.storage()
+            .instance()
+            .remove(&DataKey::RoleExpiry(role.clone(), target.clone()));
+
         env.events()
             .publish((Symbol::new(&env, "role_revoked"),), (role, target));
         Ok(())
@@ -544,6 +548,27 @@ mod tests {
 
         // Verify role is no longer present
         assert!(!client.has_role(&user, &role));
+    }
+
+    #[test]
+    fn test_revoke_role_removes_expiry() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "editor");
+        let user = Address::generate(&env);
+
+        client.grant_role(&admin, &user, &role, &Some(100))
+            .expect("grant_role should succeed");
+
+        client.revoke_role(&admin, &role, &user);
+
+        // After revoke_role, is_role_expired returns false
+        assert!(!client.is_role_expired(&role, &user));
+
+        // No RoleExpiry key exists in storage
+        let has_expiry: bool = env.as_contract(&client.address, || {
+            env.storage().instance().has(&DataKey::RoleExpiry(role.clone(), user.clone()))
+        });
+        assert!(!has_expiry);
     }
 
     #[test]


### PR DESCRIPTION
**Summary:** This PR addresses an issue where revoking a role left orphaned expiry data in the contract's instance storage.

Description: Previously, when revoke_role was executed, the HasRole, RoleMembers, and AddressRoles storage keys were successfully cleared. However, the RoleExpiry(role, target) key was left behind. This could lead to unnecessary consumption of metered ledger space and cause is_role_expired to return misleading results for a revoked role.

This update adds the missing cleanup step to the revoke_role function so that RoleExpiry is completely removed alongside the other role data.

**Changes made:**

- Added env.storage().instance().remove(&DataKey::RoleExpiry(role.clone(), target.clone())); to the revoke_role function in contracts/router-access/src/lib.rs.
- Added a new unit test test_revoke_role_removes_expiry to explicitly test that the expiry key is wiped from storage upon revocation.


Closes https://github.com/Maki-Zeninn/stellar-router/issues/212