### PR TITLE
fix: resolve issues #180, #188, #190, #191 - add InvalidMetadata erro…

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -71,6 +71,7 @@ pub enum RouterError {
     RouterPaused = 6,
     RouteAlreadyExists = 7,
     InvalidRouteName = 8,
+    InvalidMetadata = 9,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -147,10 +148,10 @@ impl RouterCore {
         // Validate metadata if provided
         if let Some(ref meta) = metadata {
             if meta.description.len() > 256 {
-                return Err(RouterError::RouteNotFound); // Using existing error for simplicity
+                return Err(RouterError::InvalidMetadata);
             }
             if meta.tags.len() > 5 {
-                return Err(RouterError::RouteNotFound);
+                return Err(RouterError::InvalidMetadata);
             }
         }
 
@@ -471,10 +472,10 @@ impl RouterCore {
         // Validate metadata if provided
         if let Some(ref meta) = metadata {
             if meta.description.len() > 256 {
-                return Err(RouterError::RouteNotFound);
+                return Err(RouterError::InvalidMetadata);
             }
             if meta.tags.len() > 5 {
-                return Err(RouterError::RouteNotFound);
+                return Err(RouterError::InvalidMetadata);
             }
         }
 
@@ -1409,5 +1410,173 @@ mod tests {
         // Verify updated_by is now B
         let entry = client.get_route(&name).unwrap();
         assert_eq!(entry.updated_by, new_admin);
+    }
+
+    // ── RouteMetadata validation tests (issues #180 & #191) ──────────────────
+
+    #[test]
+    fn test_update_metadata_description_too_long_returns_invalid_metadata() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+
+        // 257-char description — must fail
+        let long_desc = String::from_str(&env, &"a".repeat(257));
+        let metadata = Some(RouteMetadata {
+            description: long_desc,
+            tags: Vec::new(&env),
+            owner: None,
+        });
+        assert_eq!(
+            client.try_update_metadata(&admin, &name, &metadata),
+            Err(Ok(RouterError::InvalidMetadata))
+        );
+    }
+
+    #[test]
+    fn test_update_metadata_too_many_tags_returns_invalid_metadata() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+
+        // 6 tags — must fail
+        let mut tags = Vec::new(&env);
+        for i in 0..6u32 {
+            tags.push_back(String::from_str(&env, &i.to_string()));
+        }
+        let metadata = Some(RouteMetadata {
+            description: String::from_str(&env, "valid"),
+            tags,
+            owner: None,
+        });
+        assert_eq!(
+            client.try_update_metadata(&admin, &name, &metadata),
+            Err(Ok(RouterError::InvalidMetadata))
+        );
+    }
+
+    #[test]
+    fn test_update_metadata_valid_succeeds() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+
+        let mut tags = Vec::new(&env);
+        tags.push_back(String::from_str(&env, "defi"));
+        let metadata = Some(RouteMetadata {
+            description: String::from_str(&env, "valid description"),
+            tags,
+            owner: None,
+        });
+        assert!(client.try_update_metadata(&admin, &name, &metadata).is_ok());
+        assert_eq!(client.get_metadata(&name), metadata);
+    }
+
+    #[test]
+    fn test_update_metadata_clears_when_none() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+
+        let metadata = Some(RouteMetadata {
+            description: String::from_str(&env, "initial"),
+            tags: Vec::new(&env),
+            owner: None,
+        });
+        client.register_route(&admin, &name, &addr, &metadata);
+        assert!(client.get_metadata(&name).is_some());
+
+        client.update_metadata(&admin, &name, &None);
+        assert_eq!(client.get_metadata(&name), None);
+    }
+
+    #[test]
+    fn test_update_metadata_description_at_limit() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+
+        // Exactly 256 chars — must succeed
+        let desc = String::from_str(&env, &"a".repeat(256));
+        let metadata = Some(RouteMetadata {
+            description: desc,
+            tags: Vec::new(&env),
+            owner: None,
+        });
+        assert!(client.try_update_metadata(&admin, &name, &metadata).is_ok());
+    }
+
+    #[test]
+    fn test_update_metadata_description_over_limit() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+
+        // 257 chars — must fail
+        let desc = String::from_str(&env, &"a".repeat(257));
+        let metadata = Some(RouteMetadata {
+            description: desc,
+            tags: Vec::new(&env),
+            owner: None,
+        });
+        assert_eq!(
+            client.try_update_metadata(&admin, &name, &metadata),
+            Err(Ok(RouterError::InvalidMetadata))
+        );
+    }
+
+    #[test]
+    fn test_update_metadata_tags_at_limit() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+
+        // Exactly 5 tags — must succeed
+        let mut tags = Vec::new(&env);
+        for i in 0..5u32 {
+            tags.push_back(String::from_str(&env, &i.to_string()));
+        }
+        let metadata = Some(RouteMetadata {
+            description: String::from_str(&env, "valid"),
+            tags,
+            owner: None,
+        });
+        assert!(client.try_update_metadata(&admin, &name, &metadata).is_ok());
+    }
+
+    #[test]
+    fn test_update_metadata_tags_over_limit() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+
+        // 6 tags — must fail
+        let mut tags = Vec::new(&env);
+        for i in 0..6u32 {
+            tags.push_back(String::from_str(&env, &i.to_string()));
+        }
+        let metadata = Some(RouteMetadata {
+            description: String::from_str(&env, "valid"),
+            tags,
+            owner: None,
+        });
+        assert_eq!(
+            client.try_update_metadata(&admin, &name, &metadata),
+            Err(Ok(RouterError::InvalidMetadata))
+        );
+    }
+
+    #[test]
+    fn test_get_metadata_nonexistent_route_returns_none() {
+        let (env, _admin, client) = setup();
+        let name = String::from_str(&env, "nonexistent");
+        assert_eq!(client.get_metadata(&name), None);
     }
 }

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -807,6 +807,21 @@ impl RouterTimelock {
             .unwrap_or(0)
     }
 
+    /// Returns true if the given address is a member of the emergency council.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `addr` - The address to check.
+    ///
+    /// # Returns
+    /// `true` if `addr` is in the emergency council list, `false` otherwise.
+    pub fn is_council_member(env: Env, addr: Address) -> bool {
+        let council: Vec<Address> = env.storage().instance()
+            .get(&DataKey::EmergencyCouncil)
+            .unwrap_or_else(|| Vec::new(&env));
+        council.iter().any(|m| m == addr)
+    }
+
     /// Returns true if a critical operation has collected enough approvals to be fast-tracked.
     ///
     /// # Arguments
@@ -1652,5 +1667,27 @@ mod tests {
             client.try_set_fast_track_enabled(&attacker, &true),
             Err(Ok(TimelockError::Unauthorized))
         );
+    }
+
+    // ── is_council_member (issue #188) ────────────────────────────────────────
+
+    #[test]
+    fn test_is_council_member_false_before_setup() {
+        let (env, _admin, client) = setup();
+        let addr = Address::generate(&env);
+        assert!(!client.is_council_member(&addr));
+    }
+
+    #[test]
+    fn test_is_council_member_true_after_setup() {
+        let (env, admin, client, m1, _, _) = setup_with_council();
+        assert!(client.is_council_member(&m1));
+    }
+
+    #[test]
+    fn test_is_council_member_false_for_non_member() {
+        let (env, admin, client, _, _, _) = setup_with_council();
+        let outsider = Address::generate(&env);
+        assert!(!client.is_council_member(&outsider));
     }
 }


### PR DESCRIPTION

<h3>Summary</h3>
<p>This PR resolves four open issues across <code>router-core</code> and <code>router-timelock</code>. It fixes a wrong error variant being returned during metadata validation, adds a missing getter function, and fills in the missing test coverage for metadata validation logic.</p>
<hr>
<h3>Changes</h3>
<h4><code>contracts/router-core/src/lib.rs</code></h4>
<p><strong>Bug fix — wrong error variant (issue #180)</strong></p>
<p><code>update_metadata</code> and <code>register_route</code> were both returning <code>RouterError::RouteNotFound</code> when metadata validation failed, which is semantically incorrect and misleading to callers.</p>
<ul>
<li>Added a new error variant <code>InvalidMetadata = 9</code> to <code>RouterError</code></li>
<li>Replaced all four incorrect <code>RouteNotFound</code> returns in the metadata validation blocks of both <code>register_route</code> and <code>update_metadata</code> with <code>InvalidMetadata</code></li>
</ul>
<p><strong>New tests — RouteMetadata validation (issues #180 &amp; #191)</strong></p>
<p>Added 8 tests covering all metadata validation paths:</p>

Test | Covers
-- | --
test_update_metadata_description_too_long_returns_invalid_metadata | 257-char description → InvalidMetadata
test_update_metadata_too_many_tags_returns_invalid_metadata | 6 tags → InvalidMetadata
test_update_metadata_valid_succeeds | valid metadata → Ok
test_update_metadata_clears_when_none | None clears existing metadata
test_update_metadata_description_at_limit | exactly 256 chars → Ok
test_update_metadata_description_over_limit | 257 chars → InvalidMetadata
test_update_metadata_tags_at_limit | exactly 5 tags → Ok
test_update_metadata_tags_over_limit | 6 tags → InvalidMetadata
test_get_metadata_nonexistent_route_returns_none | unknown route → None


<p>Note: Tests for <code>has_sufficient_approvals</code> (issue #190) were already present in the file from a prior commit.</p>
<hr>
<h3>Closes</h3>
<p>Closes #180
Closes #188 
Closes #190 
Closes #191 </p>
<hr>
<h3>Test plan</h3>
<pre><code class="language-bash">cargo test -p router-core
cargo test -p router-timelock
</code></pre>
<p>All existing tests continue to pass. New tests are additive only — no existing behaviour was changed beyond the error variant fix.</p>
</body></html><!--EndFragment-->
</body>
</html>