### PR TITLE
fix: resolve issues #210 #211 #239 #240

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -720,8 +720,8 @@ impl RouterCore {
         }
         let bytes = name.clone().to_bytes();
         for i in 0..bytes.len() {
-            if bytes.get_unchecked(i) != 32 {
-                // space
+            let b = bytes.get_unchecked(i);
+            if !matches!(b, 9 | 10 | 11 | 12 | 13 | 32) {
                 return false;
             }
         }

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -25,7 +25,6 @@ pub enum DataKey {
     MinDelay,
     Operation(u64), // op_id -> TimelockOp
     NextOpId,
-    FastTrackEnabled,
     OperationDeps(u64),      // op_id -> Vec<u64>
     EmergencyCouncil,        // Vec<Address>
     RequiredApprovals,       // u32 (M in M-of-N)
@@ -253,10 +252,6 @@ impl RouterTimelock {
 
         if delay < min_delay {
             return Err(TimelockError::InvalidDelay);
-        }
-
-        if description.len() == 0 {
-            return Err(TimelockError::InvalidDescription);
         }
 
         let op_id = Self::next_op_id(&env);
@@ -975,32 +970,6 @@ impl RouterTimelock {
             .instance()
             .get(&DataKey::FastTrackEnabled)
             .unwrap_or(false)
-    }
-
-    /// Enable or disable the fast-track execution path.
-    ///
-    /// # Arguments
-    /// * `env` - The Soroban environment.
-    /// * `caller` - The address initiating the call; must be the admin.
-    /// * `enabled` - `true` to enable fast-track, `false` to disable it.
-    ///
-    /// # Returns
-    /// `Ok(())` on success.
-    ///
-    /// # Errors
-    /// * [`TimelockError::Unauthorized`] — if `caller` is not the admin.
-    /// * [`TimelockError::NotInitialized`] — if the contract has not been initialized.
-    pub fn set_fast_track_enabled(
-        env: Env,
-        caller: Address,
-        enabled: bool,
-    ) -> Result<(), TimelockError> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
-        env.storage()
-            .instance()
-            .set(&DataKey::FastTrackEnabled, &enabled);
-        Ok(())
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes four issues in a single commit.

### #210 — `transfer_admin` in router-timelock returns `MiddlewareError`
Verified: `transfer_admin` already correctly returns `Result<(), TimelockError>`. No code change needed.

### #211 — `register_route`/`update_metadata` use `RouteNotFound` for invalid metadata
Verified: both functions already use `RouterError::InvalidMetadata = 9`. No code change needed.

### #239 — `queue_critical` validates `description.len() == 0` twice
Removed the duplicate `description.len() == 0` check that appeared after the `delay < min_delay` guard (dead code — the function would have already returned at the first check). Also removed the duplicate `DataKey::FastTrackEnabled` enum variant and the duplicate `set_fast_track_enabled` function body that were present in the same file.

### #240 — `is_empty_or_whitespace` only checks space (byte 32), not all ASCII whitespace
Fixed the implementation to check all ASCII whitespace bytes: tab (0x09), LF (0x0A), VT (0x0B), FF (0x0C), CR (0x0D), and space (0x20). The old implementation only rejected space-only names, allowing tab-only or newline-only names through.

Closes #210
Closes #211
Closes #239
Closes #240