### PR TITLE
fix: correct configure_route arg count and remove contradictory white…

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -1176,20 +1176,6 @@ mod tests {
     }
 
     #[test]
-    fn test_register_whitespace_route_name_succeeds() {
-        // Soroban strings don't support byte iteration so whitespace-only names
-        // are treated as valid non-empty names.
-        let (env, admin, client) = setup();
-        let whitespace_name = String::from_str(&env, "   ");
-        let addr = Address::generate(&env);
-        assert!(client
-            .try_register_route(&admin, &whitespace_name, &addr, &None)
-            .is_ok());
-        let result = client.try_register_route(&admin, &whitespace_name, &addr, &None);
-        assert_eq!(result, Err(Ok(RouterError::InvalidRouteName)));
-    }
-
-    #[test]
     fn test_register_mixed_whitespace_name_fails() {
         let (env, admin, client) = setup();
         let addr = Address::generate(&env);

--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -1448,7 +1448,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // failure_threshold=1, recovery_window=60s
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &60);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0);
 
         let caller = Address::generate(&env);
 


### PR DESCRIPTION
add missing &0 log_retention arg to test_circuit_breaker_state_reset_after_recovery configure_route call
remove test_register_whitespace_route_name_succeeds which contradicts test_register_space_only_name_fails and the rest of the whitespace rejection suite
Closes #285 
Closes #286 
Closes #287 
Closes #288 