### PR TITLE
test: add missing coverage for #312 #313 #314 #315

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -881,4 +881,14 @@ mod tests {
         assert!(!members_after.contains(&user));
         assert!(members_after.is_empty());
     }
+
+    #[test]
+    fn test_set_role_admin_unauthorized_fails() {
+        let (env, _admin, client) = setup();
+        let role = String::from_str(&env, "operator");
+        let attacker = Address::generate(&env);
+        let target = Address::generate(&env);
+        let result = client.try_set_role_admin(&attacker, &role, &target);
+        assert_eq!(result, Err(Ok(AccessError::Unauthorized)));
+    }
 }

--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -1894,4 +1894,23 @@ mod tests {
         client.resolve(&name);
         assert_eq!(client.total_routed(), 2);
     }
+
+    #[test]
+    fn test_update_metadata_nonexistent_route_fails() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "ghost");
+        let result = client.try_update_metadata(&admin, &name, &None);
+        assert_eq!(result, Err(Ok(RouterError::RouteNotFound)));
+    }
+
+    #[test]
+    fn test_update_metadata_unauthorized_fails() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+        let attacker = Address::generate(&env);
+        let result = client.try_update_metadata(&attacker, &name, &None);
+        assert_eq!(result, Err(Ok(RouterError::Unauthorized)));
+    }
 }

--- a/contracts/router-multicall/src/lib.rs
+++ b/contracts/router-multicall/src/lib.rs
@@ -757,4 +757,23 @@ mod tests {
 
             assert_eq!(event_caller, caller);
         }
+
+    #[test]
+    fn test_total_batches_not_incremented_when_required_call_fails() {
+        let (env, _admin, client) = setup();
+        let mock_id = env.register_contract(None, MockContract);
+        let caller = Address::generate(&env);
+
+        let mut calls = Vec::new(&env);
+        calls.push_back(CallDescriptor {
+            target: mock_id.clone(),
+            function: Symbol::new(&env, "fail"),
+            required: true,
+            instruction_budget: None,
+        });
+
+        let result = client.try_execute_batch(&caller, &calls, &false);
+        assert_eq!(result, Err(Ok(MulticallError::RequiredCallFailed)));
+        assert_eq!(client.total_batches(), 0);
+    }
 }

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -1144,4 +1144,29 @@ mod tests {
         assert_eq!(names.len(), 1);
         assert!(names.contains(&name));
     }
+
+    #[test]
+    fn test_get_all_versions_includes_deprecated() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let a1 = Address::generate(&env);
+        let a2 = Address::generate(&env);
+        client.register(&admin, &name, &a1, &1);
+        client.register(&admin, &name, &a2, &2);
+        client.deprecate(&admin, &name, &1);
+
+        let entries = client.get_all_versions(&name);
+        assert_eq!(entries.len(), 2);
+        let v1 = entries.iter().find(|e| e.version == 1).unwrap();
+        let v2 = entries.iter().find(|e| e.version == 2).unwrap();
+        assert!(v1.deprecated);
+        assert!(!v2.deprecated);
+    }
+
+    #[test]
+    fn test_get_all_versions_empty_for_unknown_name() {
+        let (env, _admin, client) = setup();
+        let name = String::from_str(&env, "unknown");
+        assert!(client.get_all_versions(&name).is_empty());
+    }
 }


### PR DESCRIPTION
- router-access: test_set_role_admin_unauthorized_fails (#312)
- router-multicall: test_total_batches_not_incremented_when_required_call_fails (#313)
- router-registry: test_get_all_versions_includes_deprecated, test_get_all_versions_empty_for_unknown_name (#314)
- router-core: test_update_metadata_nonexistent_route_fails, test_update_metadata_unauthorized_fails (#315)

Closes #312 
Closes #313 
Closes #314 
Closes #315 