### PR TITLE
feat: resolve #306 #339 #340 #341 — timelock, mock RPC, Docker, README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+# ── Build stage ───────────────────────────────────────────────────────────────
+FROM rust:1.78-slim AS builder
+
+# Install wasm32 target for contract compilation
+RUN rustup target add wasm32-unknown-unknown
+
+WORKDIR /app
+
+# Cache dependencies before copying source
+COPY Cargo.toml Cargo.lock ./
+COPY contracts/ contracts/
+COPY metrics/ metrics/
+COPY integration-tests/ integration-tests/
+
+# Build all workspace members (native, for tests)
+RUN cargo build --workspace 2>&1
+
+# ── Test stage ────────────────────────────────────────────────────────────────
+FROM builder AS test
+CMD ["cargo", "test", "--workspace"]
+
+# ── WASM build stage ──────────────────────────────────────────────────────────
+FROM builder AS wasm
+RUN cargo build --target wasm32-unknown-unknown --release \
+    --package router-core \
+    --package router-registry \
+    --package router-access \
+    --package router-middleware \
+    --package router-timelock \
+    --package router-multicall
+
+# ── Metrics exporter runtime ──────────────────────────────────────────────────
+FROM builder AS metrics-builder
+RUN cargo build --release --package router-metrics-exporter
+
+FROM debian:bookworm-slim AS metrics
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=metrics-builder /app/target/release/router-metrics-exporter /usr/local/bin/
+EXPOSE 9090
+ENTRYPOINT ["router-metrics-exporter"]

--- a/README.md
+++ b/README.md
@@ -97,14 +97,45 @@ setting `max_batch_size`).
 ## Getting Started
 
 ### Prerequisites
-- Rust (stable)
-- Soroban CLI: `cargo install --locked stellar-cli`
 
-### Build
+| Tool | Install |
+|---|---|
+| Rust (stable) | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
+| wasm32 target | `rustup target add wasm32-unknown-unknown` |
+| Stellar CLI | `cargo install --locked stellar-cli` |
+| Docker (optional) | [docs.docker.com](https://docs.docker.com/get-docker/) |
+
+### Quick Start (Docker)
+
+The fastest way to get a working environment with no local Rust install:
 
 ```bash
 git clone https://github.com/Maki-Zeninn/stellar-router.git
 cd stellar-router
+
+# Run all unit tests
+docker compose run tests
+
+# Build WASM contract artifacts (output → ./artifacts/)
+docker compose run wasm
+
+# Start metrics stack (exporter + Prometheus + Grafana)
+docker compose up
+```
+
+Grafana is available at http://localhost:3000 (admin / admin).
+Prometheus is available at http://localhost:9091.
+
+### Manual Setup
+
+```bash
+git clone https://github.com/Maki-Zeninn/stellar-router.git
+cd stellar-router
+```
+
+### Build
+
+```bash
 cargo build
 ```
 
@@ -235,13 +266,46 @@ stellar contract invoke --id <MIDDLEWARE_ID> --network testnet --source admin \
 ### Queue a timelock operation
 
 ```bash
+# 1. Queue the operation (delay = 86400 seconds = 24 hours)
 stellar contract invoke --id <TIMELOCK_ID> --network testnet --source admin \
   -- queue \
   --proposer <ADMIN_ADDRESS> \
   --description "upgrade oracle to v2" \
   --target <NEW_ORACLE_ADDRESS> \
   --delay 86400
+
+# 2. Wait for the delay to pass (24 hours on testnet)
+
+# 3. Execute the operation after the ETA
+stellar contract invoke --id <TIMELOCK_ID> --network testnet --source admin \
+  -- execute \
+  --caller <ADMIN_ADDRESS> \
+  --op_id <OP_ID_FROM_QUEUE>
+
+# Or cancel it before execution
+stellar contract invoke --id <TIMELOCK_ID> --network testnet --source admin \
+  -- cancel \
+  --caller <ADMIN_ADDRESS> \
+  --op_id <OP_ID_FROM_QUEUE>
 ```
+
+## Troubleshooting
+
+**`cargo build` fails with `wasm32-unknown-unknown` target not found**
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+**`stellar contract deploy` fails with "account not found"**
+Fund your testnet account using [Stellar Friendbot](https://friendbot.stellar.org/?addr=<YOUR_ADDRESS>).
+
+**Metrics exporter shows no data**
+- Verify the contract IDs are correct and the contracts are initialized.
+- Check that `ROUTER_RPC_URL` points to a live Soroban RPC endpoint.
+- Run `docker compose logs metrics-exporter` to see scrape errors.
+
+**Tests fail with "AlreadyInitialized"**
+Each test must use a fresh `Env::default()` and register a new contract instance. The Soroban test environment is isolated per `Env`, so this should not happen unless a test helper is reusing state.
 
 ## FAQ
 

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -1,2 +1,412 @@
 #![no_std]
-// Placeholder — implementation pending.
+
+//! # router-timelock
+//!
+//! Delayed execution queue for sensitive router configuration changes.
+//! Operations must wait a configurable minimum delay before execution.
+//! Operations can be cancelled before execution.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, crypto::Hash, Address, Bytes, Env,
+    String, Symbol, Vec,
+};
+
+// ── Storage Keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    MinDelay,
+    Op(Bytes), // op_id -> Op
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Op {
+    pub proposer: Address,
+    pub description: String,
+    pub target: Address,
+    pub eta: u64,
+    pub executed: bool,
+    pub cancelled: bool,
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TimelockError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    NotFound = 4,
+    NotReady = 5,
+    AlreadyExecuted = 6,
+    Cancelled = 7,
+    DelayTooShort = 8,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct RouterTimelock;
+
+#[contractimpl]
+impl RouterTimelock {
+    /// Initialize with an admin and minimum delay (seconds).
+    pub fn initialize(env: Env, admin: Address, min_delay: u64) -> Result<(), TimelockError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(TimelockError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::MinDelay, &min_delay);
+        Ok(())
+    }
+
+    /// Queue an operation. Returns the op_id (SHA-256 of description + target + eta).
+    /// Emits `op_queued` with `(op_id, target, eta)`.
+    pub fn queue(
+        env: Env,
+        proposer: Address,
+        description: String,
+        target: Address,
+        delay: u64,
+        _deps: Vec<Bytes>,
+    ) -> Result<Bytes, TimelockError> {
+        proposer.require_auth();
+        Self::require_admin(&env, &proposer)?;
+
+        let min_delay: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinDelay)
+            .ok_or(TimelockError::NotInitialized)?;
+
+        if delay < min_delay {
+            return Err(TimelockError::DelayTooShort);
+        }
+
+        let eta = env.ledger().timestamp() + delay;
+
+        // Derive op_id from description bytes + target bytes + eta
+        let mut preimage = Bytes::new(&env);
+        preimage.append(&description.to_bytes());
+        preimage.append(&target.clone().to_xdr(&env));
+        let eta_bytes = eta.to_be_bytes();
+        preimage.append(&Bytes::from_array(&env, &eta_bytes));
+
+        let op_id: Bytes = env.crypto().sha256(&preimage).into();
+
+        let op = Op {
+            proposer,
+            description,
+            target: target.clone(),
+            eta,
+            executed: false,
+            cancelled: false,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::Op(op_id.clone()), &op);
+
+        env.events().publish(
+            (Symbol::new(&env, "op_queued"),),
+            (op_id.clone(), target, eta),
+        );
+
+        Ok(op_id)
+    }
+
+    /// Cancel a queued operation before it is executed.
+    pub fn cancel(env: Env, caller: Address, op_id: Bytes) -> Result<(), TimelockError> {
+        caller.require_auth();
+        Self::require_admin(&env, &caller)?;
+
+        let mut op: Op = env
+            .storage()
+            .instance()
+            .get(&DataKey::Op(op_id.clone()))
+            .ok_or(TimelockError::NotFound)?;
+
+        if op.executed {
+            return Err(TimelockError::AlreadyExecuted);
+        }
+        if op.cancelled {
+            return Err(TimelockError::Cancelled);
+        }
+
+        op.cancelled = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::Op(op_id.clone()), &op);
+
+        env.events()
+            .publish((Symbol::new(&env, "op_cancelled"),), op_id);
+
+        Ok(())
+    }
+
+    /// Execute a queued operation after its ETA has passed.
+    pub fn execute(env: Env, caller: Address, op_id: Bytes) -> Result<(), TimelockError> {
+        caller.require_auth();
+        Self::require_admin(&env, &caller)?;
+
+        let mut op: Op = env
+            .storage()
+            .instance()
+            .get(&DataKey::Op(op_id.clone()))
+            .ok_or(TimelockError::NotFound)?;
+
+        if op.cancelled {
+            return Err(TimelockError::Cancelled);
+        }
+        if op.executed {
+            return Err(TimelockError::AlreadyExecuted);
+        }
+        if env.ledger().timestamp() < op.eta {
+            return Err(TimelockError::NotReady);
+        }
+
+        op.executed = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::Op(op_id.clone()), &op);
+
+        env.events()
+            .publish((Symbol::new(&env, "op_executed"),), (op_id, op.target));
+
+        Ok(())
+    }
+
+    /// Get an operation by id.
+    pub fn get_op(env: Env, op_id: Bytes) -> Option<Op> {
+        env.storage().instance().get(&DataKey::Op(op_id))
+    }
+
+    /// Get the minimum delay.
+    pub fn min_delay(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinDelay)
+            .unwrap_or(0)
+    }
+
+    /// Get the admin.
+    pub fn admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), TimelockError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(TimelockError::NotInitialized)?;
+        if &admin != caller {
+            return Err(TimelockError::Unauthorized);
+        }
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Events, Ledger},
+        Bytes, Env, IntoVal, String,
+    };
+
+    fn setup() -> (Env, Address, RouterTimelockClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, RouterTimelock);
+        let client = RouterTimelockClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &3600);
+        (env, admin, client)
+    }
+
+    #[test]
+    fn test_queue_returns_op_id() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        assert!(!op_id.is_empty());
+    }
+
+    #[test]
+    fn test_queue_emits_op_queued_event() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+
+        let events = env.events().all();
+        let last = events.last().unwrap();
+
+        // Topic is "op_queued"
+        let topic: Symbol = last.1.get(0).unwrap().into_val(&env);
+        assert_eq!(topic, Symbol::new(&env, "op_queued"));
+
+        // Payload is (op_id, target, eta)
+        let (emitted_id, emitted_target, emitted_eta): (Bytes, Address, u64) =
+            last.2.into_val(&env);
+        assert_eq!(emitted_id, op_id);
+        assert_eq!(emitted_target, target);
+        assert!(emitted_eta > 0);
+    }
+
+    #[test]
+    fn test_queue_stores_op() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        let op = client.get_op(&op_id).unwrap();
+
+        assert_eq!(op.target, target);
+        assert!(!op.executed);
+        assert!(!op.cancelled);
+    }
+
+    #[test]
+    fn test_execute_before_eta_fails() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        let result = client.try_execute(&admin, &op_id);
+        assert_eq!(result, Err(Ok(TimelockError::NotReady)));
+    }
+
+    #[test]
+    fn test_execute_after_eta_succeeds() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        env.ledger().with_mut(|l| l.timestamp += 3601);
+        client.execute(&admin, &op_id);
+
+        let op = client.get_op(&op_id).unwrap();
+        assert!(op.executed);
+    }
+
+    #[test]
+    fn test_cancel_op() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        client.cancel(&admin, &op_id);
+
+        let op = client.get_op(&op_id).unwrap();
+        assert!(op.cancelled);
+    }
+
+    #[test]
+    fn test_execute_cancelled_op_fails() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        client.cancel(&admin, &op_id);
+        env.ledger().with_mut(|l| l.timestamp += 3601);
+        let result = client.try_execute(&admin, &op_id);
+        assert_eq!(result, Err(Ok(TimelockError::Cancelled)));
+    }
+
+    #[test]
+    fn test_execute_twice_fails() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        env.ledger().with_mut(|l| l.timestamp += 3601);
+        client.execute(&admin, &op_id);
+        let result = client.try_execute(&admin, &op_id);
+        assert_eq!(result, Err(Ok(TimelockError::AlreadyExecuted)));
+    }
+
+    #[test]
+    fn test_delay_too_short_fails() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+        // min_delay is 3600, passing 100 should fail
+        let result = client.try_queue(&admin, &desc, &target, &100, &deps);
+        assert_eq!(result, Err(Ok(TimelockError::DelayTooShort)));
+    }
+
+    #[test]
+    fn test_unauthorized_queue_fails() {
+        let (env, _admin, client) = setup();
+        let attacker = Address::generate(&env);
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+        let result = client.try_queue(&attacker, &desc, &target, &3600, &deps);
+        assert_eq!(result, Err(Ok(TimelockError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_execute_emits_op_executed_event() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        env.ledger().with_mut(|l| l.timestamp += 3601);
+        client.execute(&admin, &op_id);
+
+        let events = env.events().all();
+        let last = events.last().unwrap();
+        let topic: Symbol = last.1.get(0).unwrap().into_val(&env);
+        assert_eq!(topic, Symbol::new(&env, "op_executed"));
+    }
+
+    #[test]
+    fn test_cancel_emits_op_cancelled_event() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &deps);
+        client.cancel(&admin, &op_id);
+
+        let events = env.events().all();
+        let last = events.last().unwrap();
+        let topic: Symbol = last.1.get(0).unwrap().into_val(&env);
+        assert_eq!(topic, Symbol::new(&env, "op_cancelled"));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+version: "3.9"
+
+# ── stellar-router local development stack ────────────────────────────────────
+#
+# Usage:
+#   docker compose up            # start everything
+#   docker compose run tests     # run unit tests only
+#   docker compose run wasm      # build WASM contract artifacts
+#
+# The metrics stack (exporter + Prometheus + Grafana) mirrors the setup in
+# metrics/docker-compose.yml but wires the exporter to the local build.
+
+services:
+  # ── Unit tests ──────────────────────────────────────────────────────────────
+  tests:
+    build:
+      context: .
+      target: test
+    volumes:
+      - cargo-cache:/usr/local/cargo/registry
+      - target-cache:/app/target
+    profiles: ["tests"]
+
+  # ── WASM contract build ─────────────────────────────────────────────────────
+  wasm:
+    build:
+      context: .
+      target: wasm
+    volumes:
+      - cargo-cache:/usr/local/cargo/registry
+      - target-cache:/app/target
+      - ./artifacts:/app/target/wasm32-unknown-unknown/release
+    profiles: ["wasm"]
+
+  # ── Metrics exporter ────────────────────────────────────────────────────────
+  metrics-exporter:
+    build:
+      context: .
+      target: metrics
+    environment:
+      ROUTER_RPC_URL: ${ROUTER_RPC_URL:-https://soroban-testnet.stellar.org}
+      ROUTER_CORE_CONTRACT_ID: ${ROUTER_CORE_CONTRACT_ID:-}
+      ROUTER_MIDDLEWARE_CONTRACT_ID: ${ROUTER_MIDDLEWARE_CONTRACT_ID:-}
+      ROUTER_REGISTRY_CONTRACT_ID: ${ROUTER_REGISTRY_CONTRACT_ID:-}
+      ROUTER_SCRAPE_INTERVAL_SECS: ${ROUTER_SCRAPE_INTERVAL_SECS:-15}
+    ports:
+      - "9090:9090"
+    depends_on:
+      - prometheus
+
+  # ── Prometheus ───────────────────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.51.2
+    volumes:
+      - ./metrics/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9091:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+
+  # ── Grafana ──────────────────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:10.4.2
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+
+volumes:
+  cargo-cache:
+  target-cache:
+  prometheus-data:
+  grafana-data:
+  artifacts:

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -34,6 +34,9 @@ clap = { version = "4.5.37", features = ["derive", "env"] }
 # Error handling
 anyhow = { version = "1.0.98" }
 
+# Async trait support
+async-trait = { version = "0.1.88" }
+
 # Validation
 validator = { version = "0.19.0", features = ["derive"] }
 # Rate limiting

--- a/metrics/src/collector.rs
+++ b/metrics/src/collector.rs
@@ -26,7 +26,7 @@ use tracing::{error, info, warn};
 
 use crate::cli::Args;
 use crate::metrics::RouterMetrics;
-use crate::rpc::SorobanRpcClient;
+use crate::rpc::{RpcClient, SorobanRpcClient};
 
 /// Drives the periodic scrape loop.
 #[derive(Clone)]
@@ -65,7 +65,7 @@ impl Collector {
 
     /// Scrape all configured contracts.  Returns `true` if every scrape
     /// succeeded, `false` if any failed.
-    async fn scrape_all(&self, client: &SorobanRpcClient) -> bool {
+    async fn scrape_all(&self, client: &dyn RpcClient) -> bool {
         let mut all_ok = true;
 
         if !self.args.core_contract_id.is_empty() {
@@ -112,7 +112,7 @@ impl Collector {
 
     // ── router-core ───────────────────────────────────────────────────────────
 
-    async fn scrape_core(&self, client: &SorobanRpcClient, contract_id: &str) -> Result<()> {
+    async fn scrape_core(&self, client: &dyn RpcClient, contract_id: &str) -> Result<()> {
         let start = Instant::now();
         info!(contract_id, "scraping router-core");
 
@@ -182,7 +182,7 @@ impl Collector {
 
     // ── router-middleware ─────────────────────────────────────────────────────
 
-    async fn scrape_middleware(&self, client: &SorobanRpcClient, contract_id: &str) -> Result<()> {
+    async fn scrape_middleware(&self, client: &dyn RpcClient, contract_id: &str) -> Result<()> {
         let start = Instant::now();
         info!(contract_id, "scraping router-middleware");
 
@@ -247,7 +247,7 @@ impl Collector {
 
     // ── router-registry ───────────────────────────────────────────────────────
 
-    async fn scrape_registry(&self, client: &SorobanRpcClient, contract_id: &str) -> Result<()> {
+    async fn scrape_registry(&self, client: &dyn RpcClient, contract_id: &str) -> Result<()> {
         let start = Instant::now();
         info!(contract_id, "scraping router-registry");
 
@@ -275,7 +275,167 @@ impl Collector {
     }
 }
 
-// ── Value extraction helpers ──────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::MockRpcClient;
+    use prometheus::Registry;
+    use serde_json::json;
+
+    fn make_collector(
+        core: &str,
+        middleware: &str,
+        registry_id: &str,
+    ) -> (Collector, RouterMetrics) {
+        let reg = Registry::new();
+        let metrics = RouterMetrics::new(&reg).unwrap();
+        let args = Args {
+            rpc_url: String::new(),
+            network_passphrase: String::new(),
+            core_contract_id: core.to_string(),
+            middleware_contract_id: middleware.to_string(),
+            registry_contract_id: registry_id.to_string(),
+            scrape_interval_secs: 15,
+            listen: "0.0.0.0:9090".to_string(),
+            rpc_timeout_secs: 10,
+        };
+        let collector = Collector::new(args, metrics.clone());
+        (collector, metrics)
+    }
+
+    #[tokio::test]
+    async fn test_scrape_core_updates_metrics() {
+        let (collector, metrics) = make_collector("CORE_ID", "", "");
+
+        let mock = MockRpcClient::new()
+            .with_u64("CORE_ID", "total_routed", 42)
+            .with_string_vec("CORE_ID", "get_all_routes", vec![]);
+
+        let ok = collector.scrape_all(&mock).await;
+        assert!(ok);
+
+        let val = metrics
+            .core_total_routed
+            .with_label_values(&["CORE_ID"])
+            .get();
+        assert_eq!(val, 42.0);
+    }
+
+    #[tokio::test]
+    async fn test_scrape_middleware_updates_metrics() {
+        let (collector, metrics) = make_collector("", "MW_ID", "");
+
+        let mock = MockRpcClient::new()
+            .with_u64("MW_ID", "total_calls", 7)
+            .with_string_vec("MW_ID", "get_configured_routes", vec![]);
+
+        let ok = collector.scrape_all(&mock).await;
+        assert!(ok);
+
+        let val = metrics
+            .middleware_total_calls
+            .with_label_values(&["MW_ID"])
+            .get();
+        assert_eq!(val, 7.0);
+    }
+
+    #[tokio::test]
+    async fn test_scrape_registry_updates_metrics() {
+        let (collector, metrics) = make_collector("", "", "REG_ID");
+
+        let mock = MockRpcClient::new().with_string_vec(
+            "REG_ID",
+            "get_all_names",
+            vec!["oracle".to_string(), "vault".to_string()],
+        );
+
+        let ok = collector.scrape_all(&mock).await;
+        assert!(ok);
+
+        let val = metrics
+            .registry_total_names
+            .with_label_values(&["REG_ID"])
+            .get();
+        assert_eq!(val, 2.0);
+    }
+
+    #[tokio::test]
+    async fn test_scrape_failure_returns_false_and_increments_error_counter() {
+        let (collector, metrics) = make_collector("CORE_ID", "", "");
+
+        // Mock returns no response → scrape_core will fail
+        let mock = MockRpcClient::new();
+
+        let ok = collector.scrape_all(&mock).await;
+        assert!(!ok);
+
+        let errors = metrics
+            .scrape_errors_total
+            .with_label_values(&["CORE_ID"])
+            .get();
+        assert_eq!(errors, 1.0);
+    }
+
+    #[tokio::test]
+    async fn test_scrape_core_with_routes_and_circuit_breaker() {
+        let (collector, metrics) = make_collector("CORE_ID", "MW_ID", "");
+
+        let mock = MockRpcClient::new()
+            .with_u64("CORE_ID", "total_routed", 100)
+            .with_string_vec(
+                "CORE_ID",
+                "get_all_routes",
+                vec!["oracle".to_string()],
+            )
+            .with_simulate(
+                "CORE_ID",
+                "get_route",
+                json!({ "results": [{ "retval": { "paused": false } }] }),
+            )
+            .with_u64("MW_ID", "total_calls", 50)
+            .with_string_vec(
+                "MW_ID",
+                "get_configured_routes",
+                vec!["oracle".to_string()],
+            )
+            .with_simulate(
+                "MW_ID",
+                "circuit_breaker_state",
+                json!({
+                    "results": [{
+                        "retval": {
+                            "some": { "is_open": true, "failure_count": 3, "opened_at": 1000 }
+                        }
+                    }]
+                }),
+            );
+
+        let ok = collector.scrape_all(&mock).await;
+        assert!(ok);
+
+        assert_eq!(
+            metrics
+                .core_total_routed
+                .with_label_values(&["CORE_ID"])
+                .get(),
+            100.0
+        );
+        assert_eq!(
+            metrics
+                .middleware_circuit_open
+                .with_label_values(&["MW_ID", "oracle"])
+                .get(),
+            1.0
+        );
+        assert_eq!(
+            metrics
+                .middleware_failure_count
+                .with_label_values(&["MW_ID", "oracle"])
+                .get(),
+            3.0
+        );
+    }
+}
 
 /// Encode a plain string as a base64 XDR `ScVal::String` argument.
 ///

--- a/metrics/src/rpc.rs
+++ b/metrics/src/rpc.rs
@@ -6,6 +6,7 @@
 //! requires `wasm32` toolchain features and complicates native builds).
 
 use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -335,6 +336,175 @@ pub fn instance_storage_key_xdr(_contract_id: &str) -> Result<String> {
         "Direct XDR key construction not implemented. \
          Use the simulation path or integrate stellar-xdr."
     ))
+}
+
+// ── RpcClient trait ───────────────────────────────────────────────────────────
+
+/// Trait abstracting the Soroban RPC calls used by the collector.
+///
+/// Implement this trait with [`MockRpcClient`] in tests to avoid live network
+/// access, or use the real [`SorobanRpcClient`] in production.
+#[async_trait::async_trait]
+pub trait RpcClient: Send + Sync {
+    async fn call_u64(&self, contract_id: &str, function_name: &str) -> Result<u64>;
+    async fn call_bool(&self, contract_id: &str, function_name: &str) -> Result<bool>;
+    async fn call_string_vec(
+        &self,
+        contract_id: &str,
+        function_name: &str,
+    ) -> Result<Vec<String>>;
+    async fn simulate_invoke(
+        &self,
+        contract_id: &str,
+        function_name: &str,
+        args_xdr: Vec<String>,
+    ) -> Result<serde_json::Value>;
+}
+
+#[async_trait::async_trait]
+impl RpcClient for SorobanRpcClient {
+    async fn call_u64(&self, contract_id: &str, function_name: &str) -> Result<u64> {
+        self.call_u64(contract_id, function_name).await
+    }
+    async fn call_bool(&self, contract_id: &str, function_name: &str) -> Result<bool> {
+        self.call_bool(contract_id, function_name).await
+    }
+    async fn call_string_vec(
+        &self,
+        contract_id: &str,
+        function_name: &str,
+    ) -> Result<Vec<String>> {
+        self.call_string_vec(contract_id, function_name).await
+    }
+    async fn simulate_invoke(
+        &self,
+        contract_id: &str,
+        function_name: &str,
+        args_xdr: Vec<String>,
+    ) -> Result<serde_json::Value> {
+        self.simulate_invoke(contract_id, function_name, args_xdr)
+            .await
+    }
+}
+
+// ── MockRpcClient ─────────────────────────────────────────────────────────────
+
+/// A deterministic mock RPC client for use in tests.
+///
+/// Pre-load responses via the builder methods; any call not explicitly
+/// configured returns an error so tests fail loudly on unexpected calls.
+///
+/// # Example
+/// ```rust
+/// let mock = MockRpcClient::new()
+///     .with_u64("CONTRACT", "total_routed", 42)
+///     .with_string_vec("CONTRACT", "get_all_routes", vec![]);
+/// ```
+#[cfg(any(test, feature = "test-utils"))]
+pub struct MockRpcClient {
+    u64_responses: std::collections::HashMap<(String, String), u64>,
+    bool_responses: std::collections::HashMap<(String, String), bool>,
+    string_vec_responses: std::collections::HashMap<(String, String), Vec<String>>,
+    simulate_responses:
+        std::collections::HashMap<(String, String), serde_json::Value>,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl MockRpcClient {
+    pub fn new() -> Self {
+        Self {
+            u64_responses: Default::default(),
+            bool_responses: Default::default(),
+            string_vec_responses: Default::default(),
+            simulate_responses: Default::default(),
+        }
+    }
+
+    pub fn with_u64(mut self, contract: &str, func: &str, val: u64) -> Self {
+        self.u64_responses
+            .insert((contract.to_string(), func.to_string()), val);
+        self
+    }
+
+    pub fn with_bool(mut self, contract: &str, func: &str, val: bool) -> Self {
+        self.bool_responses
+            .insert((contract.to_string(), func.to_string()), val);
+        self
+    }
+
+    pub fn with_string_vec(mut self, contract: &str, func: &str, val: Vec<String>) -> Self {
+        self.string_vec_responses
+            .insert((contract.to_string(), func.to_string()), val);
+        self
+    }
+
+    pub fn with_simulate(
+        mut self,
+        contract: &str,
+        func: &str,
+        val: serde_json::Value,
+    ) -> Self {
+        self.simulate_responses
+            .insert((contract.to_string(), func.to_string()), val);
+        self
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+#[async_trait::async_trait]
+impl RpcClient for MockRpcClient {
+    async fn call_u64(&self, contract_id: &str, function_name: &str) -> Result<u64> {
+        self.u64_responses
+            .get(&(contract_id.to_string(), function_name.to_string()))
+            .copied()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MockRpcClient: no u64 response for {contract_id}::{function_name}"
+                )
+            })
+    }
+
+    async fn call_bool(&self, contract_id: &str, function_name: &str) -> Result<bool> {
+        self.bool_responses
+            .get(&(contract_id.to_string(), function_name.to_string()))
+            .copied()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MockRpcClient: no bool response for {contract_id}::{function_name}"
+                )
+            })
+    }
+
+    async fn call_string_vec(
+        &self,
+        contract_id: &str,
+        function_name: &str,
+    ) -> Result<Vec<String>> {
+        self.string_vec_responses
+            .get(&(contract_id.to_string(), function_name.to_string()))
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MockRpcClient: no string_vec response for {contract_id}::{function_name}"
+                )
+            })
+    }
+
+    async fn simulate_invoke(
+        &self,
+        contract_id: &str,
+        function_name: &str,
+        _args_xdr: Vec<String>,
+    ) -> Result<serde_json::Value> {
+        self.simulate_responses
+            .get(&(contract_id.to_string(), function_name.to_string()))
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MockRpcClient: no simulate response for {contract_id}::{function_name}"
+                )
+            })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary


### #306 — router-timelock contract + op_queued event test

- Implemented `queue`, `cancel`, `execute` with configurable `min_delay`
- `queue` emits `op_queued(op_id, target, eta)` — now verified in `test_queue_emits_op_queued_event`
- 10 unit tests covering happy path, error cases, and all three events

closes #306 

### #339 — Mock RPC client for metrics tests

- Extracted `RpcClient` async trait from `SorobanRpcClient`
- Added `MockRpcClient` with builder API (`with_u64`, `with_string_vec`, `with_simulate`)
- Updated `Collector` to accept `&dyn RpcClient` — no live network needed in tests
- 5 async `#[tokio::test]` tests in `collector.rs` using the mock

closes #339 

### #340 — Docker setup for local development

- Root `Dockerfile` with `test`, `wasm`, and `metrics` build targets
- Root `docker-compose.yml`: `docker compose run tests`, `docker compose run wasm`, `docker compose up` for full stack
- Includes Prometheus + Grafana wired to the metrics exporter

closes #340 

### #341 — README improvements

- Added prerequisites table with install commands
- Added Docker Quick Start section
- Expanded timelock usage example with full queue → wait → execute/cancel flow
- Added Troubleshooting section

closes #341 

## Testing

Unit tests run with `cargo test --workspace`. Metrics collector tests use `MockRpcClient` — no Soroban RPC endpoint required.