### PR TITLE
docs: add router-execution and router-quote to contracts table

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ composable, upgradeable, and access-controlled multi-contract systems on Soroban
 | `router-middleware` | Rate limiting, route enable/disable, and call event logging | 6 |
 | `router-timelock` | Delayed execution queue for sensitive configuration changes | 7 |
 | `router-multicall` | Batch multiple cross-contract calls in one transaction | 6 |
+| `router-execution` | Execution pipeline with simulation, retries, and fee estimation | 8 |
+| `router-quote` | Read-only quote preview contract for expected output, fees, and route details | 4 |
 
 ## Metrics & Monitoring
 


### PR DESCRIPTION
## Summary
- add the missing `router-execution` and `router-quote` rows to the README contracts table
- include brief descriptions and current unit-test counts for both workspace members

## Validation
- verified the workspace members in `Cargo.toml`
- verified the current `#[test]` counts in `contracts/router-execution/src/lib.rs` (8) and `contracts/router-quote/src/lib.rs` (4)

Closes #425