### PR TITLE
docs: include router-execution and router-quote in deployment order

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,19 @@ stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/router_multicall.wasm \
   --network testnet --source <your-account>
 
-# 6. Deploy core last (depends on all others)
+# 6. Deploy core
 stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/router_core.wasm \
+  --network testnet --source <your-account>
+
+# 7. Deploy execution (depends on router-core)
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/router_execution.wasm \
+  --network testnet --source <your-account>
+
+# 8. Deploy quote last (depends on router-execution)
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/router_quote.wasm \
   --network testnet --source <your-account>
 ```
 


### PR DESCRIPTION
## Summary
- add the missing `router-execution` and `router-quote` deployment commands to the README
- place them after `router-core` to reflect the dependency order described in issue #426

## Validation
- checked the current README deployment block against issue #426
- verified the new commands point at the existing `router_execution.wasm` and `router_quote.wasm` artifact names

Closes #426