### PR TITLE
feat(router-quote): add slippage_bps and expires_at (#382 #383)

### DIFF
--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -16,6 +16,13 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Vec,
 };
 
+// ── Storage Keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    QuoteTtl, // TTL for quotes in ledger seconds
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /// Request parameters for getting a quote.
@@ -50,6 +57,8 @@ pub struct QuoteResponse {
     pub exchange_rate: String,
     /// Price impact estimate (basis points, negative = adverse)
     pub price_impact_bps: i32,
+    /// Quote expiration timestamp (ledger seconds)
+    pub expires_at: u64,
 }
 
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -61,6 +70,7 @@ pub enum QuoteError {
     InvalidAmount = 2,
     QuoteFailed = 3,
     InvalidRoute = 4,
+    NotInitialized = 5,
 }
 
 /// Request parameters for fee estimation.
@@ -99,6 +109,23 @@ pub struct RouterQuote;
 
 #[contractimpl]
 impl RouterQuote {
+    /// Set the quote TTL (time-to-live) in ledger seconds.
+    ///
+    /// Configures how long quotes remain valid. Quotes will expire at
+    /// `current_ledger_timestamp + ttl_seconds`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `ttl_seconds` - Quote validity duration in ledger seconds.
+    pub fn set_quote_ttl(env: Env, ttl_seconds: u64) {
+        env.storage().instance().set(&DataKey::QuoteTtl, &ttl_seconds);
+    }
+
+    /// Get the current quote TTL in ledger seconds (default: 300).
+    pub fn get_quote_ttl(env: Env) -> u64 {
+        env.storage().instance().get(&DataKey::QuoteTtl).unwrap_or(300)
+    }
+
     /// Get a quote from a liquidity plugin.
     ///
     /// Resolves the route name to a contract address via router-core (if provided),
@@ -115,7 +142,8 @@ impl RouterQuote {
     /// * `amount_in` - The amount of token_in to swap.
     ///
     /// # Returns
-    /// A [`QuoteResponse`] containing the expected output amount, fees, and route details.
+    /// A [`QuoteResponse`] containing the expected output amount, fees, and route details,
+    /// with expires_at set based on the configured quote TTL.
     ///
     /// # Errors
     /// * [`QuoteError::InvalidAmount`] — if `amount_in` is less than or equal to zero.
@@ -133,6 +161,10 @@ impl RouterQuote {
         if amount_in <= 0 {
             return Err(QuoteError::InvalidAmount);
         }
+
+        // Compute expiration timestamp from configurable TTL (default 300s)
+        let quote_ttl: u64 = env.storage().instance().get(&DataKey::QuoteTtl).unwrap_or(300);
+        let expires_at = env.ledger().timestamp() + quote_ttl;
 
         // Resolve target address
         let target: Address = match router_core {
@@ -184,6 +216,7 @@ impl RouterQuote {
             min_amount_out,
             exchange_rate,
             price_impact_bps,
+            expires_at,
         })
     }
 
@@ -226,6 +259,7 @@ impl RouterQuote {
                         min_amount_out: 0,
                         exchange_rate: String::from_str(&env, "0"),
                         price_impact_bps: 0,
+                        expires_at: env.ledger().timestamp(),
                     });
                 }
             }

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -9,8 +9,13 @@
 //! ## Features
 //! - Get quote from any registered liquidity plugin
 //! - Returns expected output amount, fees, and route details
+//! - Caller-specified slippage tolerance via `slippage_bps` parameter
+//! - Quote expiration via configurable TTL (`set_quote_ttl` / `get_quote_ttl`)
 //! - Does not execute transactions (read-only preview)
 //! - Works with any plugin implementing the get_quote interface
+//!
+//! ## Events
+//! - `fee_estimated` — emitted on each `estimate_fee` call (total_fee, surge_pricing)
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Vec,

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -37,6 +37,8 @@ pub struct QuoteRequest {
     pub token_out: Address,
     /// The amount of token_in to swap
     pub amount_in: i128,
+    /// Slippage tolerance in basis points (e.g., 50 = 0.5%)
+    pub slippage_bps: u32,
 }
 
 /// Response containing quote details.
@@ -71,6 +73,7 @@ pub enum QuoteError {
     QuoteFailed = 3,
     InvalidRoute = 4,
     NotInitialized = 5,
+    InvalidSlippage = 6,
 }
 
 /// Request parameters for fee estimation.
@@ -140,6 +143,7 @@ impl RouterQuote {
     /// * `token_in` - The address of the token being sold.
     /// * `token_out` - The address of the token being bought.
     /// * `amount_in` - The amount of token_in to swap.
+    /// * `slippage_bps` - Slippage tolerance in basis points (e.g., 50 = 0.5%). Max 10000 (100%).
     ///
     /// # Returns
     /// A [`QuoteResponse`] containing the expected output amount, fees, and route details,
@@ -147,6 +151,7 @@ impl RouterQuote {
     ///
     /// # Errors
     /// * [`QuoteError::InvalidAmount`] — if `amount_in` is less than or equal to zero.
+    /// * [`QuoteError::InvalidSlippage`] — if `slippage_bps` exceeds 10000.
     /// * [`QuoteError::RouteNotFound`] — if the route name is not registered.
     /// * [`QuoteError::QuoteFailed`] — if the plugin's `get_quote` call fails.
     pub fn get_quote(
@@ -156,10 +161,14 @@ impl RouterQuote {
         token_in: Address,
         token_out: Address,
         amount_in: i128,
+        slippage_bps: u32,
     ) -> Result<QuoteResponse, QuoteError> {
         // Validate input
         if amount_in <= 0 {
             return Err(QuoteError::InvalidAmount);
+        }
+        if slippage_bps > 10_000 {
+            return Err(QuoteError::InvalidSlippage);
         }
 
         // Compute expiration timestamp from configurable TTL (default 300s)
@@ -199,8 +208,9 @@ impl RouterQuote {
         // Calculate fee (assuming 1% fee for now - in production this comes from the plugin)
         let fee_amount = amount_in * 1 / 100;
         
-        // Calculate min_amount_out with 0.5% slippage tolerance
-        let min_amount_out = amount_out * 999 / 1000;
+        // Calculate min_amount_out using caller-specified slippage_bps
+        // Formula: amount_out * (10000 - slippage_bps) / 10000
+        let min_amount_out = amount_out * (10_000 - slippage_bps as i128) / 10_000;
         
         // Exchange rate placeholder
         let exchange_rate = String::from_str(&env, "0");
@@ -245,6 +255,7 @@ impl RouterQuote {
                 req.token_in.clone(),
                 req.token_out.clone(),
                 req.amount_in,
+                req.slippage_bps,
             );
             
             match response {

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -416,4 +416,44 @@ mod tests {
         // Only 2 valid requests
         assert_eq!(responses.len(), 2);
     }
+
+    #[test]
+    fn test_set_and_get_quote_ttl() {
+        let (_, client) = setup();
+        assert_eq!(client.get_quote_ttl(), 300); // default
+        client.set_quote_ttl(&600);
+        assert_eq!(client.get_quote_ttl(), 600);
+    }
+
+    #[test]
+    fn test_get_quote_invalid_slippage() {
+        let (env, client) = setup();
+        let token_in = Address::generate(&env);
+        let token_out = Address::generate(&env);
+        let result = client.try_get_quote(
+            &None,
+            &String::from_str(&env, "test"),
+            &token_in,
+            &token_out,
+            &1_000_000,
+            &10_001, // > 10000
+        );
+        assert_eq!(result, Err(Ok(QuoteError::InvalidSlippage)));
+    }
+
+    #[test]
+    fn test_get_quote_invalid_amount() {
+        let (env, client) = setup();
+        let token_in = Address::generate(&env);
+        let token_out = Address::generate(&env);
+        let result = client.try_get_quote(
+            &None,
+            &String::from_str(&env, "test"),
+            &token_in,
+            &token_out,
+            &0,
+            &50,
+        );
+        assert_eq!(result, Err(Ok(QuoteError::InvalidAmount)));
+    }
 }


### PR DESCRIPTION
## Summary

Resolves #382 and #383.

### #383 — Add `slippage_bps` parameter to `get_quote()`
- Added `slippage_bps: u32` field to `QuoteRequest`
- Added `slippage_bps` parameter to `get_quote()` (replaces hardcoded 0.5%)
- Validates `slippage_bps <= 10000`, returns `InvalidSlippage` otherwise
- `min_amount_out = amount_out * (10000 - slippage_bps) / 10000`
- Added `InvalidSlippage = 6` error variant

### #382 — Add `expires_at` field to `QuoteResponse`
- Added `DataKey::QuoteTtl` storage key
- Added `expires_at: u64` field to `QuoteResponse`
- Added `set_quote_ttl()` and `get_quote_ttl()` functions (default: 300s)
- Populates `expires_at = ledger.timestamp() + ttl` in every quote
- Added `NotInitialized = 5` error variant

### Tests
- `test_set_and_get_quote_ttl`
- `test_get_quote_invalid_slippage`
- `test_get_quote_invalid_amount`

closes #383 
closes #382