### PR TITLE
docs: add error code reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,6 +4,94 @@ Complete reference for all public functions across the six stellar-router contra
 
 ---
 
+## Error Code Reference
+
+Soroban contract errors are emitted as numeric enum discriminants. Error names
+and values are scoped to each contract, so the same numeric value can mean
+different things depending on which contract returned it.
+
+### router-core `RouterError`
+
+| Error | Value | When it occurs | How to handle it |
+| --- | ---: | --- | --- |
+| `AlreadyInitialized` | 1 | `initialize` is called after the router has already been initialized. | Treat initialization as complete, or deploy a fresh contract if you need a new admin. |
+| `NotInitialized` | 2 | Admin-only helpers are called before `initialize` has stored the admin. | Initialize the router before calling configuration or admin reads. |
+| `Unauthorized` | 3 | The caller is not the stored router admin. | Sign with the admin account or transfer admin first. |
+| `RouteNotFound` | 4 | A route or alias lookup targets a name that is not registered. | Register the route, check spelling, or remove stale aliases in the caller. |
+| `RoutePaused` | 5 | `resolve` targets a route that has been individually paused. | Unpause the route or route traffic elsewhere. |
+| `RouterPaused` | 6 | `resolve` is called while the global router pause is active. | Wait for recovery or have the admin call `set_paused(false)`. |
+| `RouteAlreadyExists` | 7 | Registering a route or alias with a name that is already in use. | Choose a unique name or update/remove the existing route first. |
+| `InvalidRouteName` | 8 | A route name is empty or only whitespace. | Send a non-empty, trimmed route name. |
+| `InvalidMetadata` | 9 | Route metadata exceeds limits: description over 256 characters or more than 5 tags. | Shorten the description or reduce the tag list before submitting. |
+
+### router-registry `RegistryError`
+
+| Error | Value | When it occurs | How to handle it |
+| --- | ---: | --- | --- |
+| `AlreadyInitialized` | 1 | `initialize` is called after the registry has already been initialized. | Skip initialization or deploy a fresh registry for a new admin. |
+| `NotInitialized` | 2 | Admin-dependent registry operations run before initialization. | Initialize the registry before writes or admin reads. |
+| `Unauthorized` | 3 | The caller is not the registry admin. | Sign with the admin account or transfer admin first. |
+| `NotFound` | 4 | No entry exists for the requested name/version, or no version satisfies a lookup. | Register the contract or adjust the requested name, version, or constraint. |
+| `AlreadyRegistered` | 5 | The same `(name, version)` pair is registered twice. | Use a new version or deprecate old entries instead of overwriting. |
+| `AlreadyDeprecated` | 6 | `deprecate` targets an entry that is already deprecated. | Treat the operation as already complete or choose another version. |
+| `InvalidVersion` | 7 | Version is `0` or not greater than the current highest version for the name. | Use a positive version greater than existing versions. |
+| `VersionNotFound` | 8 | `deprecate` targets a version that is not registered for the name. | Check `versions(name)` and retry with an existing version. |
+| `InvalidConstraint` | 9 | A semver constraint cannot be parsed or uses an unsupported form. | Use exact, `>`, `>=`, `<`, `<=`, `^`, or `~` constraints. |
+| `AllVersionsDeprecated` | 10 | Lookup finds versions, but every matching entry is deprecated. | Register a newer active version or allow deprecated versions in the caller logic. |
+
+### router-access `AccessError`
+
+| Error | Value | When it occurs | How to handle it |
+| --- | ---: | --- | --- |
+| `AlreadyInitialized` | 1 | `initialize` is called after the access contract has already been initialized. | Skip initialization or deploy a fresh access contract. |
+| `NotInitialized` | 2 | Admin or role checks require the super-admin before it is stored. | Initialize the contract with a super-admin first. |
+| `Unauthorized` | 3 | The caller lacks super-admin or role-admin authority for the action. | Use an authorized signer or grant the required admin role first. |
+| `AlreadyHasRole` | 4 | `grant_role` targets an address that already holds the role directly. | Treat as success, wait for expiry, or revoke before granting again. |
+| `RoleNotFound` | 5 | `revoke_role` targets an address without that direct role grant. | Check `has_role` or role member lists before revoking. |
+| `Blacklisted` | 6 | A blacklisted address is granted or checked for role access. | Unblacklist the address before granting roles. |
+| `CannotBlacklistAdmin` | 7 | The caller tries to blacklist the super-admin address. | Transfer super-admin first, or choose another target. |
+| `HierarchyCycle` | 8 | Setting a role admin would create a parent-role cycle. | Pick a role-admin hierarchy that does not point back to itself. |
+
+### router-middleware `MiddlewareError`
+
+| Error | Value | When it occurs | How to handle it |
+| --- | ---: | --- | --- |
+| `AlreadyInitialized` | 1 | `initialize` is called after middleware has already been initialized. | Skip initialization or deploy a fresh middleware contract. |
+| `NotInitialized` | 2 | Middleware configuration or admin reads run before initialization. | Initialize the contract before route configuration. |
+| `Unauthorized` | 3 | The caller is not the middleware admin. | Sign with the admin account or transfer admin first. |
+| `RateLimitExceeded` | 4 | A caller has used all allowed calls for the route's current window. | Retry after the window resets or raise the configured limit. |
+| `RouteDisabled` | 5 | `pre_call` runs against a route whose middleware config is disabled. | Enable the route or bypass it intentionally. |
+| `MiddlewareDisabled` | 6 | Global middleware enforcement is disabled. | Re-enable middleware or treat the route as temporarily unavailable. |
+| `InvalidConfig` | 7 | Rate limiting is enabled with `max_calls_per_window > 0` but `window_seconds == 0`. | Set a positive window or set `max_calls_per_window` to `0` for unlimited calls. |
+| `CircuitOpen` | 8 | The route's circuit breaker is open after repeated failures. | Wait for the recovery window, reset the breaker, or fix the failing downstream route. |
+
+### router-timelock `TimelockError`
+
+| Error | Value | When it occurs | How to handle it |
+| --- | ---: | --- | --- |
+| `AlreadyInitialized` | 1 | `initialize` is called after the timelock has already been initialized. | Skip initialization or deploy a fresh timelock contract. |
+| `NotInitialized` | 2 | Timelock operations need the admin or delay before initialization. | Initialize the timelock with an admin and minimum delay. |
+| `Unauthorized` | 3 | The caller is not the timelock admin. | Sign with the admin account or transfer admin first. |
+| `NotFound` | 4 | `execute` or `cancel` targets an unknown operation id. | Recompute the operation id or query the operation before acting. |
+| `NotReady` | 5 | `execute` is called before the queued operation's ETA. | Wait until the ETA has passed. |
+| `AlreadyExecuted` | 6 | `execute` or `cancel` targets an operation that has already executed. | Treat it as complete and avoid replaying the operation. |
+| `Cancelled` | 7 | `execute` or `cancel` targets an operation that has been cancelled. | Queue a new operation if the action is still needed. |
+| `DelayTooShort` | 8 | `queue` uses a delay lower than the configured minimum delay. | Use at least `min_delay()` seconds. |
+
+### router-multicall `MulticallError`
+
+| Error | Value | When it occurs | How to handle it |
+| --- | ---: | --- | --- |
+| `AlreadyInitialized` | 1 | `initialize` is called after multicall has already been initialized. | Skip initialization or deploy a fresh multicall contract. |
+| `NotInitialized` | 2 | Batch execution or admin reads require config before initialization. | Initialize the contract with an admin and batch size. |
+| `Unauthorized` | 3 | The caller is not the multicall admin for configuration changes. | Sign with the admin account or transfer admin first. |
+| `BatchTooLarge` | 4 | `execute_batch` receives more calls than `max_batch_size`. | Split the batch or increase `max_batch_size`. |
+| `EmptyBatch` | 5 | `execute_batch` is called with no calls. | Provide at least one call descriptor. |
+| `RequiredCallFailed` | 6 | A required call in the batch fails. | Inspect per-call results, fix the failed required call, or mark it optional if safe. |
+| `InvalidConfig` | 7 | `max_batch_size` is set to `0`. | Configure a positive maximum batch size. |
+
+---
+
 ## router-core
 
 **Contract:** `RouterCore`  


### PR DESCRIPTION
## Summary
- add a consolidated Error Code Reference section to docs/api-reference.md
- document each documented contract error enum with numeric value, trigger, and recovery guidance
- note that numeric discriminants are scoped per contract

## Verification
- git diff --check
- cargo unavailable in this environment (docs-only change)

Closes #464