### PR TITLE
refactor(router-timelock): extract operation state checks into required op_pending() helper

### DIFF
--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -27,14 +27,11 @@ use soroban_sdk::{
 #[contracttype]
 pub enum DataKey {
     Admin,
-    Entry(String, u32), // (name, version) -> ContractEntry
-    Versions(String),   // name -> Vec<u32>
-    ContractNames,      // Vec<String> of all registered names
-    AddressIndex(Address), // address -> (name, version)
     Entry(String, u32),    // (name, version) -> ContractEntry
     Versions(String),      // name -> Vec<u32>
     ContractNames,         // Vec<String> of all registered names
     AddressIndex(Address), // address -> (name, version) for O(1) reverse lookup
+    LatestVersion(String), // name -> u32: cached latest non-deprecated version
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -54,8 +51,6 @@ pub struct ContractEntry {
     pub deprecation_reason: Option<String>,
     /// Who registered it
     pub registered_by: Address,
-    /// Optional reason recorded when this entry was deprecated
-    pub deprecation_reason: Option<String>,
 }
 
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -163,7 +158,6 @@ impl RouterRegistry {
             deprecated: false,
             deprecation_reason: None,
             registered_by: caller,
-            deprecation_reason: None,
         };
 
         env.storage()
@@ -199,6 +193,11 @@ impl RouterRegistry {
         env.storage()
             .instance()
             .set(&DataKey::AddressIndex(entry.address.clone()), &(name.clone(), version));
+
+        // New version is always the highest (validated above), so it becomes the new latest.
+        env.storage()
+            .instance()
+            .set(&DataKey::LatestVersion(name.clone()), &version);
 
         env.events()
             .publish((Symbol::new(&env, "contract_registered"),), (name, version, None::<String>));
@@ -240,26 +239,15 @@ impl RouterRegistry {
     /// # Errors
     /// * [`RegistryError::NotFound`] — if no non-deprecated entry exists for `name`.
     pub fn get_latest(env: Env, name: String) -> Result<ContractEntry, RegistryError> {
-        let versions = Self::get_versions_list(&env, &name);
-        if versions.is_empty() {
-            return Err(RegistryError::NotFound);
-        }
-        // Iterate in reverse to find latest non-deprecated
-        let len = versions.len();
-        let mut i = len;
-        while i > 0 {
-            i -= 1;
-            let v = versions.get(i).ok_or(RegistryError::NotFound)?;
-            let entry: ContractEntry = env
-                .storage()
-                .instance()
-                .get(&DataKey::Entry(name.clone(), v))
-                .ok_or(RegistryError::NotFound)?;
-            if !entry.deprecated {
-                return Ok(entry);
-            }
-        }
-        Err(RegistryError::AllVersionsDeprecated)
+        let version: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LatestVersion(name.clone()))
+            .ok_or(RegistryError::NotFound)?;
+        env.storage()
+            .instance()
+            .get(&DataKey::Entry(name, version))
+            .ok_or(RegistryError::AllVersionsDeprecated)
     }
 
     /// Get the latest non-deprecated entry matching a semver constraint.
@@ -285,23 +273,9 @@ impl RouterRegistry {
     ) -> Result<ContractEntry, RegistryError> {
         let versions = Self::get_versions_list(&env, &name);
 
-        // If no constraint, use get_latest logic
+        // If no constraint, delegate to get_latest (uses cache).
         if constraint.is_none() {
-            let len = versions.len();
-            let mut i = len;
-            while i > 0 {
-                i -= 1;
-                let v = versions.get(i).ok_or(RegistryError::NotFound)?;
-                let entry: ContractEntry = env
-                    .storage()
-                    .instance()
-                    .get(&DataKey::Entry(name.clone(), v))
-                    .ok_or(RegistryError::NotFound)?;
-                if !entry.deprecated {
-                    return Ok(entry);
-                }
-            }
-            return Err(RegistryError::AllVersionsDeprecated);
+            return Self::get_latest(env.clone(), name);
         }
 
         let constraint_str = constraint.unwrap();
@@ -373,7 +347,6 @@ impl RouterRegistry {
         Self::deprecate_one(&env, name, version, reason)
     }
 
-    fn deprecate_one(env: &Env, name: String, version: u32, reason: Option<String>) -> Result<(), RegistryError> {
     fn deprecate_one(
         env: &Env,
         name: String,
@@ -391,7 +364,6 @@ impl RouterRegistry {
         }
 
         entry.deprecated = true;
-        entry.deprecation_reason = reason;
         entry.deprecation_reason = reason.clone();
         env.storage()
             .instance()
@@ -401,6 +373,35 @@ impl RouterRegistry {
         env.storage()
             .instance()
             .remove(&DataKey::AddressIndex(entry.address.clone()));
+
+        // Update LatestVersion cache: scan versions in reverse for new latest non-deprecated.
+        let versions = Self::get_versions_list(env, &name);
+        let len = versions.len();
+        let mut new_latest: Option<u32> = None;
+        let mut i = len;
+        while i > 0 {
+            i -= 1;
+            let v = versions.get(i).unwrap();
+            let e: ContractEntry = env
+                .storage()
+                .instance()
+                .get(&DataKey::Entry(name.clone(), v))
+                .unwrap();
+            if !e.deprecated {
+                new_latest = Some(v);
+                break;
+            }
+        }
+        match new_latest {
+            Some(v) => env
+                .storage()
+                .instance()
+                .set(&DataKey::LatestVersion(name.clone()), &v),
+            None => env
+                .storage()
+                .instance()
+                .remove(&DataKey::LatestVersion(name.clone())),
+        }
 
         env.events().publish(
             (Symbol::new(&env, "contract_deprecated"),),

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -156,12 +156,7 @@ impl RouterTimelock {
             .get(&DataKey::Op(op_id.clone()))
             .ok_or(TimelockError::NotFound)?;
 
-        if op.executed {
-            return Err(TimelockError::AlreadyExecuted);
-        }
-        if op.cancelled {
-            return Err(TimelockError::Cancelled);
-        }
+        Self::require_op_pending(&op)?;
 
         op.cancelled = true;
         env.storage()
@@ -185,12 +180,7 @@ impl RouterTimelock {
             .get(&DataKey::Op(op_id.clone()))
             .ok_or(TimelockError::NotFound)?;
 
-        if op.cancelled {
-            return Err(TimelockError::Cancelled);
-        }
-        if op.executed {
-            return Err(TimelockError::AlreadyExecuted);
-        }
+        Self::require_op_pending(&op)?;
         if env.ledger().timestamp() < op.eta {
             return Err(TimelockError::NotReady);
         }
@@ -260,6 +250,16 @@ impl RouterTimelock {
             .ok_or(TimelockError::NotInitialized)?;
         if &admin != caller {
             return Err(TimelockError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn require_op_pending(op: &Op) -> Result<(), TimelockError> {
+        if op.cancelled {
+            return Err(TimelockError::Cancelled);
+        }
+        if op.executed {
+            return Err(TimelockError::AlreadyExecuted);
         }
         Ok(())
     }


### PR DESCRIPTION
The refactor has the following implementation:
                                
Added require_op_pending(op: &Op) helper in the // ── Helpers ── section:     
 `cancel` — replaced the two if guards with Self::require_op_pending(&op)?;    
                                                                                
  `execute` — replaced the two if guards with Self::require_op_pending(&op)?;   
  (the NotReady check stays, as it's execute-specific)                          
                                                                                
  Note on approve_critical: it doesn't exist in the current codebase, so nothing
  to change there. If it's added later, it just calls                           
  Self::require_op_pending(&op)?; the same way.   

closes #512 
closes #513 