### PR TITLE
feat(router-middleware): add get_call_log_filtered(route, success_onl…

### DIFF
--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -637,6 +637,57 @@ impl RouterMiddleware {
         ordered
     }
 
+    /// Get a filtered call log for a route.
+    ///
+    /// Returns only successful or only failed call log entries for `route`,
+    /// reducing data transfer for monitoring use cases compared to `get_call_log`.
+    /// Entries are returned in chronological order (oldest first).
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `route` - The route name to retrieve logs for.
+    /// * `success_only` - If `true`, returns only successful entries; if `false`, returns only failed entries.
+    ///
+    /// # Returns
+    /// A [`Vec<CallLogEntry>`] containing only entries matching the filter.
+    pub fn get_call_log_filtered(env: Env, route: String, success_only: bool) -> Vec<CallLogEntry> {
+        let Some(log_state) = env
+            .storage()
+            .instance()
+            .get::<DataKey, CallLogState>(&DataKey::CallLog(route))
+        else {
+            return Vec::new(&env);
+        };
+
+        if log_state.entries.is_empty() {
+            return Vec::new(&env);
+        }
+
+        let len = log_state.entries.len();
+        let mut ordered = Vec::new(&env);
+
+        if log_state.head == 0 {
+            for i in 0..len {
+                if let Some(entry) = log_state.entries.get(i) {
+                    if entry.success == success_only {
+                        ordered.push_back(entry);
+                    }
+                }
+            }
+        } else {
+            for i in 0..len {
+                let idx = (log_state.head + i) % len;
+                if let Some(entry) = log_state.entries.get(idx) {
+                    if entry.success == success_only {
+                        ordered.push_back(entry);
+                    }
+                }
+            }
+        }
+
+        ordered
+    }
+
     /// Get the number of call log entries for a route.
     ///
     /// More efficient than loading the full call log when callers only need
@@ -1591,6 +1642,87 @@ mod tests {
         assert_eq!(topic, Symbol::new(&env, "middleware_enabled"));
         let emitted: bool = last.2.into_val(&env);
         assert!(!emitted);
+    }
+
+    // ── Issue #491: get_call_log_filtered ────────────────────────────────────
+
+    #[test]
+    fn test_get_call_log_filtered_empty_when_no_calls() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+
+        assert!(client.get_call_log_filtered(&route, &true).is_empty());
+        assert!(client.get_call_log_filtered(&route, &false).is_empty());
+    }
+
+    #[test]
+    fn test_get_call_log_filtered_success_only() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        let caller = Address::generate(&env);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+
+        client.post_call(&caller, &route, &true);
+        client.post_call(&caller, &route, &false);
+        client.post_call(&caller, &route, &true);
+
+        let filtered = client.get_call_log_filtered(&route, &true);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.get(0).unwrap().success);
+        assert!(filtered.get(1).unwrap().success);
+    }
+
+    #[test]
+    fn test_get_call_log_filtered_failure_only() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        let caller = Address::generate(&env);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+
+        client.post_call(&caller, &route, &true);
+        client.post_call(&caller, &route, &false);
+        client.post_call(&caller, &route, &false);
+
+        let filtered = client.get_call_log_filtered(&route, &false);
+        assert_eq!(filtered.len(), 2);
+        assert!(!filtered.get(0).unwrap().success);
+        assert!(!filtered.get(1).unwrap().success);
+    }
+
+    #[test]
+    fn test_get_call_log_filtered_all_success_no_failures() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        let caller = Address::generate(&env);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5);
+
+        client.post_call(&caller, &route, &true);
+        client.post_call(&caller, &route, &true);
+
+        assert!(client.get_call_log_filtered(&route, &false).is_empty());
+        assert_eq!(client.get_call_log_filtered(&route, &true).len(), 2);
+    }
+
+    #[test]
+    fn test_get_call_log_filtered_with_ring_buffer_wraparound() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        let caller = Address::generate(&env);
+        // retention=3, make 5 calls so ring buffer wraps
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3);
+
+        client.post_call(&caller, &route, &true);  // evicted
+        client.post_call(&caller, &route, &false); // evicted
+        client.post_call(&caller, &route, &true);  // retained
+        client.post_call(&caller, &route, &false); // retained
+        client.post_call(&caller, &route, &true);  // retained
+
+        // 3 retained: success, failure, success
+        let success = client.get_call_log_filtered(&route, &true);
+        let failure = client.get_call_log_filtered(&route, &false);
+        assert_eq!(success.len(), 2);
+        assert_eq!(failure.len(), 1);
     }
 
     // ── Issue #449: get_call_log_summary ─────────────────────────────────────


### PR DESCRIPTION
Closes #491

## What I built
Added `get_call_log_filtered(route, success_only)` to `contracts/router-middleware/src/lib.rs`

## Approach
- When `success_only = true` → returns only successful log entries
- When `success_only = false` → returns only failed log entries
- Reuses the same ring-buffer ordering logic as `get_call_log`
- Returns entries in chronological order (oldest first)
- Returns empty Vec if no log exists for the route

## Tests added
- Empty log returns empty for both filters
- success_only returns only successful entries
- failure_only returns only failed entries
- All-success log returns empty for failure filter
- Ring buffer wraparound handled correctly