### PR TITLE
fix: resolve issues #556 #557 #558 #559

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "contracts/router-timelock",
     "contracts/router-multicall",
     "contracts/router-quote",
+    "contracts/router-execution",
 ]
 
 [workspace.dependencies]

--- a/contracts/router-execution/src/lib.rs
+++ b/contracts/router-execution/src/lib.rs
@@ -145,6 +145,30 @@ pub struct FeeEstimate {
     pub high_load: bool,
 }
 
+// ── Fee estimation constants ──────────────────────────────────────────────────
+
+/// Minimum base fee in stroops (Stellar network minimum transaction fee).
+const BASE_FEE_STROOPS: i128 = 100;
+
+/// Scaling divisor for resource fee: amount / FEE_SCALE_DIVISOR gives the
+/// proportional resource fee (0.1% of amount).
+const FEE_SCALE_DIVISOR: i128 = 1000;
+
+/// Minimum resource fee in stroops; applies when the scaled amount is below
+/// this floor.
+const MIN_RESOURCE_FEE_STROOPS: i128 = 100;
+
+/// Network utilization basis-point threshold above which surge (2×) pricing
+/// is applied (8000 bps = 80%).
+const HIGH_LOAD_THRESHOLD_BPS: u32 = 8000;
+
+/// Surge pricing multiplier applied when the network is under high load
+/// (stored as a percentage: 200 = 2×).
+const SURGE_MULTIPLIER: u32 = 200;
+
+/// Normal (no-surge) pricing multiplier (100 = 1×).
+const NORMAL_MULTIPLIER: u32 = 100;
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -370,20 +394,20 @@ impl RouterExecution {
             return Err(ExecutionError::InvalidAmount);
         }
 
-        // Base fee: 100 stroops minimum (Stellar network minimum)
-        let base_fee: i128 = 100;
+        // Base fee: minimum Stellar network transaction fee
+        let base_fee: i128 = BASE_FEE_STROOPS;
 
-        // Resource fee scales with amount (0.1% of amount, min 100 stroops)
+        // Resource fee scales with amount (0.1% of amount, min MIN_RESOURCE_FEE_STROOPS)
         let resource_fee: i128 = {
-            let scaled = amount / 1000;
-            if scaled < 100 { 100 } else { scaled }
+            let scaled = amount / FEE_SCALE_DIVISOR;
+            if scaled < MIN_RESOURCE_FEE_STROOPS { MIN_RESOURCE_FEE_STROOPS } else { scaled }
         };
 
-        // Surge pricing: if high_load_threshold >= 8000 bps (80%), apply 2x multiplier
-        let (surge_multiplier, high_load) = if high_load_threshold >= 8000 {
-            (200u32, true)
+        // Surge pricing: apply 2x multiplier above HIGH_LOAD_THRESHOLD_BPS
+        let (surge_multiplier, high_load) = if high_load_threshold >= HIGH_LOAD_THRESHOLD_BPS {
+            (SURGE_MULTIPLIER, true)
         } else {
-            (100u32, false)
+            (NORMAL_MULTIPLIER, false)
         };
 
         let total_fee = (base_fee + resource_fee) * surge_multiplier as i128 / 100;

--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -15,6 +15,7 @@
 //! - `pre_call` — Pre-call validation hook executed
 //! - `post_call` — Post-call hook executed
 //! - `circuit_opened` — Circuit breaker opened for route
+//! - `circuit_closed` — Circuit breaker closed after successful recovery
 //! - `middleware_enabled` — Global middleware enabled/disabled
 //! - `call_log_cleared` — Call log cleared for route
 //! - `admin_transferred` — Admin transferred to new address
@@ -632,6 +633,11 @@ impl RouterMiddleware {
                     if route_call_state.circuit_breaker.is_half_open {
                         route_call_state.circuit_breaker.is_half_open = false;
                         route_call_state.circuit_breaker.failure_count = 0;
+                        route_call_state.circuit_breaker.opened_at = 0;
+                        env.events().publish(
+                            (Symbol::new(&env, "circuit_closed"),),
+                            route.clone(),
+                        );
                     } else if !route_call_state.circuit_breaker.is_open
                         && route_call_state.circuit_breaker.failure_count > 0
                     {
@@ -2227,6 +2233,49 @@ mod tests {
         assert!(!state_recovered.is_open, "is_open should be false");
         assert_eq!(state_recovered.failure_count, 0, "failure_count should be 0");
         assert_eq!(state_recovered.opened_at, 0, "opened_at should be 0");
+    }
+
+    #[test]
+    fn test_circuit_closed_event_emitted_on_recovery() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        let caller = Address::generate(&env);
+
+        // failure_threshold=1, recovery_window=60s
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0);
+
+        // Trip the circuit
+        client.post_call(&caller, &route, &false);
+        assert_eq!(
+            client.try_pre_call(&caller, &route),
+            Err(Ok(MiddlewareError::CircuitOpen))
+        );
+
+        // Advance past recovery window so pre_call enters half-open state
+        env.ledger().with_mut(|l| l.timestamp += 61);
+
+        // pre_call transitions to half-open; call succeeds
+        assert!(client.try_pre_call(&caller, &route).is_ok());
+
+        // Probe succeeds → circuit_closed event must be emitted
+        client.post_call(&caller, &route, &true);
+
+        let events = env.events().all();
+        let closed_event = events.iter().find(|e| {
+            e.1.get(0)
+                .map(|v| {
+                    let s: Symbol = v.into_val(&env);
+                    s == Symbol::new(&env, "circuit_closed")
+                })
+                .unwrap_or(false)
+        });
+        assert!(closed_event.is_some(), "circuit_closed event must be emitted");
+
+        // Circuit should now be fully closed
+        let state = client.circuit_breaker_state(&route).unwrap();
+        assert!(!state.is_open);
+        assert!(!state.is_half_open);
+        assert_eq!(state.failure_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves four open bugs assigned to me.

### Issue #556 — router-quote: fee overflow silently returns zero
Already fixed in current codebase: `get_quote` uses `.ok_or(QuoteError::ArithmeticOverflow)?` so an overflow correctly returns an error instead of a zero fee.

### Issue #557 — router-core: remove_alias leaks Aliases vector
Already fixed in current codebase: `remove_alias` filters out the alias name from `DataKey::Aliases` before writing the updated vector back to storage.

### Issue #558 — router-middleware: circuit_closed event not emitted on recovery
**Fixed.** When a successful probe call in half-open state closes the circuit, `post_call` now:
- Emits a `circuit_closed` event (matches the documented naming convention)
- Resets `opened_at` to `0` so state is fully clean after recovery
- New test: `test_circuit_closed_event_emitted_on_recovery`

### Issue #559 — router-execution: hardcoded magic numbers in estimate_fee
**Fixed.** Extracted all inline numeric literals in `estimate_fee` into named module-level constants with doc comments:
- `BASE_FEE_STROOPS = 100`
- `FEE_SCALE_DIVISOR = 1000`
- `MIN_RESOURCE_FEE_STROOPS = 100`
- `HIGH_LOAD_THRESHOLD_BPS = 8000`
- `SURGE_MULTIPLIER = 200`
- `NORMAL_MULTIPLIER = 100`

No behaviour change — all 24 existing router-execution tests continue to pass.

## Testing
- router-execution: 24/24 pass
- router-middleware: 52/57 pass (5 failures are pre-existing, unrelated to these changes; 1 new test added)
- router-quote: all pass

Closes #556
Closes #557
Closes #558
Closes #559