### PR TITLE
fix(api-server): log warning and set fee_estimated flag on RPC parse …

### DIFF
--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -60,6 +60,7 @@ pub async fn simulate(
             total_fee: breakdown.total_fee,
             surge_multiplier: breakdown.surge_multiplier,
             high_load: breakdown.high_load,
+            fee_estimated: breakdown.fee_estimated,
         },
         simulation: SimulationDetail {
             target: req.target,

--- a/api-server/src/rpc.rs
+++ b/api-server/src/rpc.rs
@@ -2,6 +2,7 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::warn;
 
 use crate::types::{RouteEntryResponse, RouteMetadataResponse};
 
@@ -62,6 +63,7 @@ pub struct FeeBreakdown {
     pub surge_multiplier: u32,
     pub high_load: bool,
     pub would_succeed: bool,
+    pub fee_estimated: bool,
 }
 
 impl SorobanRpcClient {
@@ -83,7 +85,16 @@ impl SorobanRpcClient {
         match self.call_simulate_rpc(target, function).await {
             Ok(result) => {
                 let would_succeed = result.error.is_none();
-                let resource_fee: i64 = result.min_resource_fee.parse().unwrap_or(1_000);
+                let (resource_fee, fee_estimated) = match result.min_resource_fee.parse::<i64>() {
+                    Ok(v) => (v, true),
+                    Err(_) => {
+                        warn!(
+                            raw = %result.min_resource_fee,
+                            "failed to parse min_resource_fee from RPC response; using fallback 1000 stroops"
+                        );
+                        (1_000, false)
+                    }
+                };
                 let base_fee: i64 = 100;
                 let (surge_multiplier, high_load) = if network_load_bps >= 8_000 {
                     (200u32, true)
@@ -98,6 +109,7 @@ impl SorobanRpcClient {
                     surge_multiplier,
                     high_load,
                     would_succeed,
+                    fee_estimated,
                 })
             }
             Err(_) => Ok(Self::heuristic_estimate(amount, network_load_bps)),
@@ -321,6 +333,7 @@ impl SorobanRpcClient {
             surge_multiplier,
             high_load,
             would_succeed: true,
+            fee_estimated: false,
         }
     }
 }

--- a/api-server/src/types.rs
+++ b/api-server/src/types.rs
@@ -51,6 +51,7 @@ pub struct FeeEstimate {
     pub total_fee: i64,
     pub surge_multiplier: u32,
     pub high_load: bool,
+    pub fee_estimated: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
…failure (#563)

- Add fee_estimated: bool to FeeBreakdown and FeeEstimate
- Replace .parse().unwrap_or(1_000) with explicit match that emits tracing::warn on parse failure and sets fee_estimated: false
- Heuristic fallback path also sets fee_estimated: false
- Callers can now distinguish real estimates from fallback values

Closes #563