### PR TITLE
fix: health endpoint RPC check and max_retries zero validation

### DIFF
--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -16,8 +16,11 @@ use crate::{
 };
 
 /// GET /health
-pub async fn health() -> impl IntoResponse {
-    (StatusCode::OK, Json(json!({"status": "ok"})))
+pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    match state.rpc.health_check().await {
+        Ok(()) => (StatusCode::OK, Json(json!({"status": "ok", "rpc": "up"}))),
+        Err(_) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"status": "degraded", "rpc": "down"}))),
+    }
 }
 
 /// POST /simulate

--- a/api-server/src/rpc.rs
+++ b/api-server/src/rpc.rs
@@ -75,6 +75,27 @@ impl SorobanRpcClient {
         }
     }
 
+    /// Ping the RPC node via `getLatestLedger`. Returns `Ok(())` if reachable.
+    pub async fn health_check(&self) -> Result<()> {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "getLatestLedger",
+            params: serde_json::json!({}),
+        };
+        let resp = self
+            .http
+            .post(&self.rpc_url)
+            .json(&req)
+            .send()
+            .await
+            .map_err(|e| anyhow!("RPC unreachable: {}", e))?;
+        if !resp.status().is_success() {
+            return Err(anyhow!("RPC returned status {}", resp.status()));
+        }
+        Ok(())
+    }
+
     pub async fn simulate(
         &self,
         target: &str,

--- a/api-server/src/tests.rs
+++ b/api-server/src/tests.rs
@@ -32,17 +32,17 @@ fn test_app() -> Router {
 }
 
 #[tokio::test]
-async fn test_health_returns_200() {
+async fn test_health_returns_503_when_rpc_unreachable() {
     let app = test_app();
     let resp = app
         .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
 
 #[tokio::test]
-async fn test_health_returns_ok_body() {
+async fn test_health_returns_degraded_body_when_rpc_down() {
     let app = test_app();
     let resp = app
         .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
@@ -50,7 +50,8 @@ async fn test_health_returns_ok_body() {
         .unwrap();
     let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["status"], "ok");
+    assert_eq!(json["status"], "degraded");
+    assert_eq!(json["rpc"], "down");
 }
 
 #[tokio::test]

--- a/contracts/router-execution/src/lib.rs
+++ b/contracts/router-execution/src/lib.rs
@@ -30,9 +30,6 @@ const FIXED_POINT_SCALE: u32 = 100;
 /// Minimum valid backoff multiplier: 100 = 1.0× (no growth, constant delay).
 const MIN_BACKOFF_MULTIPLIER: u32 = FIXED_POINT_SCALE;
 
-/// Base network fee in stroops — the Stellar network minimum transaction fee.
-const BASE_FEE_STROOPS: i128 = 100;
-
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -210,7 +207,7 @@ impl RouterExecution {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(ExecutionError::AlreadyInitialized);
         }
-        if max_retries > 5 {
+        if max_retries == 0 || max_retries > 5 {
             return Err(ExecutionError::InvalidConfig);
         }
         if backoff_multiplier < MIN_BACKOFF_MULTIPLIER {
@@ -420,20 +417,6 @@ impl RouterExecution {
             (SURGE_MULTIPLIER, true)
         } else {
             (NORMAL_MULTIPLIER, false)
-        // Base fee: minimum Stellar network fee in stroops
-        let base_fee: i128 = BASE_FEE_STROOPS;
-
-        // Resource fee scales with amount (0.1% of amount, min BASE_FEE_STROOPS)
-        let resource_fee: i128 = {
-            let scaled = amount / 1000;
-            if scaled < BASE_FEE_STROOPS { BASE_FEE_STROOPS } else { scaled }
-        };
-
-        // Surge pricing: if high_load_threshold >= 8000 bps (80%), apply 2x multiplier
-        let (surge_multiplier, high_load) = if high_load_threshold >= 8000 {
-            (FIXED_POINT_SCALE * 2, true)
-        } else {
-            (FIXED_POINT_SCALE, false)
         };
 
         let total_fee = (base_fee + resource_fee) * surge_multiplier as i128 / FIXED_POINT_SCALE as i128;
@@ -551,7 +534,7 @@ impl RouterExecution {
         if admin != caller {
             return Err(ExecutionError::Unauthorized);
         }
-        if new_max > 5 {
+        if new_max == 0 || new_max > 5 {
             return Err(ExecutionError::InvalidConfig);
         }
         env.storage().instance().set(&DataKey::MaxRetries, &new_max);
@@ -678,6 +661,24 @@ mod tests {
         let (_, admin, client) = setup();
         let result = client.try_initialize(&admin, &1, &0, &100);
         assert_eq!(result, Err(Ok(ExecutionError::AlreadyInitialized)));
+    }
+
+    #[test]
+    fn test_initialize_max_retries_zero_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, RouterExecution);
+        let client = RouterExecutionClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let result = client.try_initialize(&admin, &0, &0, &100);
+        assert_eq!(result, Err(Ok(ExecutionError::InvalidConfig)));
+    }
+
+    #[test]
+    fn test_set_max_retries_zero_fails() {
+        let (_, admin, client) = setup();
+        let result = client.try_set_max_retries(&admin, &0);
+        assert_eq!(result, Err(Ok(ExecutionError::InvalidConfig)));
     }
 
     #[test]


### PR DESCRIPTION
Closes #560
Closes #562

## Changes

### #560 — health endpoint RPC connectivity check
- `SorobanRpcClient::health_check()` pings `getLatestLedger` via JSON-RPC
- `GET /health` now returns **503** with `{"status":"degraded","rpc":"down"}` if RPC is unreachable, **200** with `{"status":"ok","rpc":"up"}` otherwise
- Updated tests to assert 503 when RPC is down

### #562 — max_retries zero validation
- `initialize()` and `set_max_retries()` now reject `max_retries == 0` with `InvalidConfig`
- Added `test_initialize_max_retries_zero_fails` and `test_set_max_retries_zero_fails`
- Also fixed a pre-existing duplicate constant and broken `estimate_fee` function body