### PR TITLE
refactor: consolidate shared storage helpers into router-common

### DIFF
--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -10,6 +10,16 @@
 //! - [`require_admin_simple!`] — convenience macro for standard DataKey::Admin and error variants
 //! - [`admin_transfer_complete!`] — shared admin transfer pattern (storage set + event emit)
 //!
+//! ## Storage Helpers
+//!
+//! Shared instance-storage patterns are consolidated to remove per-contract
+//! boilerplate while keeping each contract's own `DataKey` enum:
+//! - [`CommonDataKey`] — shared `Admin` storage key
+//! - [`get_admin`] / [`set_admin`] — admin address accessors
+//! - [`is_initialized`] / [`require_initialized`] / [`require_uninitialized`] — initialization guards
+//! - [`extend_instance_ttl`] — instance-storage TTL extension wrapper
+//! - [`StorageHelper`] — trait with default implementations of the above
+//!
 //! ## Event Topic Naming Convention
 //!
 //! All event topics across stellar-router contracts follow these rules:
@@ -134,7 +144,7 @@ pub const EVENT_CONTRACT_DEPRECATED: &str = "contract_deprecated";
 
 // ── Batch types ───────────────────────────────────────────────────────────────
 
-use soroban_sdk::{contracttype, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{contracttype, Address, Env, IntoVal, String, Symbol, Val, Vec};
 
 /// Per-call result payload used by multicall batch operations.
 #[contracttype]
@@ -388,4 +398,265 @@ macro_rules! admin_transfer_complete {
             );
         }
     };
+}
+
+// ── Shared storage keys & helpers ───────────────────────────────────────────────
+
+/// Shared storage key for the admin address.
+///
+/// Each contract still owns its contract-specific `DataKey` enum, but the common
+/// `Admin` key is consolidated here so the admin get/set/initialization helpers
+/// below can be reused without redefining the variant in every contract.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum CommonDataKey {
+    /// Address of the contract administrator.
+    Admin,
+}
+
+/// Reads the admin address stored under `key`, or `None` if it has not been set.
+///
+/// `key` is generic so callers can pass their own `DataKey::Admin`, the shared
+/// [`CommonDataKey::Admin`], or any equivalent storage key.
+pub fn get_admin<K>(env: &Env, key: &K) -> Option<Address>
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().instance().get(key)
+}
+
+/// Stores `admin` as the admin address under `key`.
+pub fn set_admin<K>(env: &Env, key: &K, admin: &Address)
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().instance().set(key, admin);
+}
+
+/// Returns `true` if a value is present under `key` (used as the initialization guard).
+pub fn is_initialized<K>(env: &Env, key: &K) -> bool
+where
+    K: IntoVal<Env, Val>,
+{
+    env.storage().instance().has(key)
+}
+
+/// Returns `Ok(())` when a value exists under `key`, otherwise `Err(not_init_err)`.
+///
+/// Use this to guard operations that require the contract to already be initialized.
+pub fn require_initialized<K, E>(env: &Env, key: &K, not_init_err: E) -> Result<(), E>
+where
+    K: IntoVal<Env, Val>,
+{
+    if env.storage().instance().has(key) {
+        Ok(())
+    } else {
+        Err(not_init_err)
+    }
+}
+
+/// Returns `Ok(())` when no value exists under `key`, otherwise `Err(already_init_err)`.
+///
+/// Use this in `initialize` to reject double initialization.
+pub fn require_uninitialized<K, E>(env: &Env, key: &K, already_init_err: E) -> Result<(), E>
+where
+    K: IntoVal<Env, Val>,
+{
+    if env.storage().instance().has(key) {
+        Err(already_init_err)
+    } else {
+        Ok(())
+    }
+}
+
+/// Extends the time-to-live of the contract's instance storage.
+///
+/// Thin wrapper over `env.storage().instance().extend_ttl` so the common
+/// `(threshold, extend_to)` pattern is expressed once.
+pub fn extend_instance_ttl(env: &Env, threshold: u32, extend_to: u32) {
+    env.storage().instance().extend_ttl(threshold, extend_to);
+}
+
+/// Default implementations for the admin and initialization storage patterns
+/// shared across router contracts.
+///
+/// A contract opts in by implementing the three associated items — the admin
+/// storage key plus its two initialization-related error variants — and gains
+/// the admin get/set and initialization-guard helpers for free.
+///
+/// # Example
+///
+/// ```ignore
+/// struct MyContractStorage;
+///
+/// impl router_common::StorageHelper for MyContractStorage {
+///     type Key = DataKey;
+///     type Error = MyError;
+///
+///     fn admin_key(_env: &Env) -> DataKey { DataKey::Admin }
+///     fn not_initialized_error() -> MyError { MyError::NotInitialized }
+///     fn already_initialized_error() -> MyError { MyError::AlreadyInitialized }
+/// }
+///
+/// // later:
+/// MyContractStorage::require_uninitialized(&env)?;
+/// MyContractStorage::set_admin(&env, &admin);
+/// ```
+pub trait StorageHelper {
+    /// Storage key type for this contract (typically its own `DataKey`).
+    type Key: IntoVal<Env, Val>;
+    /// Error type returned by the initialization guard helpers.
+    type Error;
+
+    /// The storage key under which the admin address is stored.
+    fn admin_key(env: &Env) -> Self::Key;
+    /// Error variant returned when the contract has not been initialized.
+    fn not_initialized_error() -> Self::Error;
+    /// Error variant returned when the contract is already initialized.
+    fn already_initialized_error() -> Self::Error;
+
+    /// Reads the admin address, or `None` if unset.
+    fn get_admin(env: &Env) -> Option<Address> {
+        crate::get_admin(env, &Self::admin_key(env))
+    }
+
+    /// Stores `admin` as the admin address.
+    fn set_admin(env: &Env, admin: &Address) {
+        crate::set_admin(env, &Self::admin_key(env), admin);
+    }
+
+    /// Returns `true` if the admin address is set.
+    fn is_initialized(env: &Env) -> bool {
+        crate::is_initialized(env, &Self::admin_key(env))
+    }
+
+    /// Errors with `not_initialized_error()` unless the contract is initialized.
+    fn require_initialized(env: &Env) -> Result<(), Self::Error> {
+        crate::require_initialized(env, &Self::admin_key(env), Self::not_initialized_error())
+    }
+
+    /// Errors with `already_initialized_error()` if the contract is already initialized.
+    fn require_uninitialized(env: &Env) -> Result<(), Self::Error> {
+        crate::require_uninitialized(
+            env,
+            &Self::admin_key(env),
+            Self::already_initialized_error(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod storage_helper_tests {
+    use super::*;
+    use soroban_sdk::{contract, contracterror, testutils::Address as _};
+
+    #[contract]
+    struct TestContract;
+
+    #[contracterror]
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    enum TestError {
+        NotInitialized = 1,
+        AlreadyInitialized = 2,
+    }
+
+    struct TestStorage;
+
+    impl StorageHelper for TestStorage {
+        type Key = CommonDataKey;
+        type Error = TestError;
+
+        fn admin_key(_env: &Env) -> CommonDataKey {
+            CommonDataKey::Admin
+        }
+        fn not_initialized_error() -> TestError {
+            TestError::NotInitialized
+        }
+        fn already_initialized_error() -> TestError {
+            TestError::AlreadyInitialized
+        }
+    }
+
+    #[test]
+    fn admin_round_trips_through_helpers() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestContract);
+        env.as_contract(&id, || {
+            let admin = Address::generate(&env);
+            assert!(get_admin(&env, &CommonDataKey::Admin).is_none());
+            set_admin(&env, &CommonDataKey::Admin, &admin);
+            assert_eq!(get_admin(&env, &CommonDataKey::Admin), Some(admin));
+        });
+    }
+
+    #[test]
+    fn initialization_guards_behave() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestContract);
+        env.as_contract(&id, || {
+            assert!(!is_initialized(&env, &CommonDataKey::Admin));
+            assert_eq!(
+                require_initialized(&env, &CommonDataKey::Admin, TestError::NotInitialized),
+                Err(TestError::NotInitialized)
+            );
+            assert_eq!(
+                require_uninitialized(
+                    &env,
+                    &CommonDataKey::Admin,
+                    TestError::AlreadyInitialized
+                ),
+                Ok(())
+            );
+
+            set_admin(&env, &CommonDataKey::Admin, &Address::generate(&env));
+
+            assert!(is_initialized(&env, &CommonDataKey::Admin));
+            assert_eq!(
+                require_initialized(&env, &CommonDataKey::Admin, TestError::NotInitialized),
+                Ok(())
+            );
+            assert_eq!(
+                require_uninitialized(
+                    &env,
+                    &CommonDataKey::Admin,
+                    TestError::AlreadyInitialized
+                ),
+                Err(TestError::AlreadyInitialized)
+            );
+        });
+    }
+
+    #[test]
+    fn trait_defaults_delegate_to_free_functions() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestContract);
+        env.as_contract(&id, || {
+            assert!(!TestStorage::is_initialized(&env));
+            assert_eq!(
+                TestStorage::require_uninitialized(&env),
+                Ok(())
+            );
+
+            let admin = Address::generate(&env);
+            TestStorage::set_admin(&env, &admin);
+
+            assert_eq!(TestStorage::get_admin(&env), Some(admin));
+            assert!(TestStorage::is_initialized(&env));
+            assert_eq!(TestStorage::require_initialized(&env), Ok(()));
+            assert_eq!(
+                TestStorage::require_uninitialized(&env),
+                Err(TestError::AlreadyInitialized)
+            );
+        });
+    }
+
+    #[test]
+    fn extend_instance_ttl_does_not_panic() {
+        let env = Env::default();
+        let id = env.register_contract(None, TestContract);
+        env.as_contract(&id, || {
+            set_admin(&env, &CommonDataKey::Admin, &Address::generate(&env));
+            extend_instance_ttl(&env, 100, 1000);
+        });
+    }
 }


### PR DESCRIPTION
closes #594

## Summary
Consolidates the storage key and admin/initialization boilerplate repeated across the seven contracts into `router-common`, complementing the existing `require_admin!` family of macros.

## Changes
Added to `router-common` (purely additive — no existing contract is modified, and each contract keeps its own contract-specific `DataKey` enum):

- `CommonDataKey` enum with the shared `Admin` storage key.
- Generic helper functions usable with any storage key (a contract's own `DataKey::Admin` or `CommonDataKey::Admin`):
  - `get_admin` / `set_admin` — admin address accessors.
  - `is_initialized`, `require_initialized`, `require_uninitialized` — initialization guards for `initialize` and admin-gated entry points.
  - `extend_instance_ttl` — wrapper over the common instance-storage TTL extension pattern.
- `StorageHelper` trait with default implementations. A contract opts in by supplying its admin key and its `NotInitialized` / `AlreadyInitialized` error variants, then gets admin get/set and the initialization guards for free.
- Crate-level documentation for the new helpers and a test module covering the free functions, the initialization guards, and the trait defaults.

## Rationale
Reduces duplicated boilerplate and ensures consistent admin/initialization behavior across contracts. Contracts can migrate incrementally; this PR introduces the shared building blocks without forcing any call-site changes.

## Notes
Cargo is unavailable in the authoring environment, so the crate was not compiled locally. The additions follow the repository's existing soroban-sdk import, `register_contract`, and `contracterror` conventions.
