### PR TITLE
feat(router-core): add route expiry/TTL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ## [Unreleased]
 
 ### Added
+- `router-core`: routes can now be registered with an optional TTL via `register_route_with_ttl`. `resolve()` returns `RouteExpired` once the current ledger exceeds a route's expiry, `get_all_routes()` excludes expired routes, and `extend_route_ttl` lets the admin extend a route's TTL before it expires. `get_route_expiry` returns a route's expiry ledger, if any. Routes registered without a TTL remain permanent.
 - `router-access`: blacklist entries can now include an optional `reason` and an `expires_at` timestamp. Expired blacklist entries are treated as not blacklisted.
 - `router-registry`: `ContractEntry` includes an optional `deprecation_reason` and the `deprecate()` API accepts an optional reason which is emitted in the `contract_deprecated` event.
 - `metrics/alerts.yml`: example Prometheus alerting rules for circuit breaker opens, high failure/error rates, and high request volume.

--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -97,6 +97,15 @@ pub const EVENT_ROUTE_TAG_ADDED: &str = "route_tag_added";
 /// Standard event topic for route tag removals
 pub const EVENT_ROUTE_TAG_REMOVED: &str = "route_tag_removed";
 
+/// Standard event topic for route TTL being set at registration
+pub const EVENT_ROUTE_TTL_SET: &str = "route_ttl_set";
+
+/// Standard event topic for route TTL extensions
+pub const EVENT_ROUTE_TTL_EXTENDED: &str = "route_ttl_extended";
+
+/// Standard event topic for resolution attempts on an expired route
+pub const EVENT_ROUTE_RESOLVE_EXPIRED: &str = "route_resolve_expired";
+
 /// Standard event topic for role grants
 pub const EVENT_ROLE_GRANTED: &str = "role_granted";
 

--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -24,6 +24,9 @@
 //! - `metadata_updated` — Route metadata updated (route_name, metadata)
 //! - `route_tag_added` — Route tag added (route_name, tag)
 //! - `route_tag_removed` — Route tag removed (route_name, tag)
+//! - `route_ttl_set` — Route TTL set at registration (route_name, expiry_ledger)
+//! - `route_ttl_extended` — Route TTL extended (route_name, new_expiry_ledger)
+//! - `route_resolve_expired` — Route resolution attempted on an expired route (route_name)
 //! - `alias_added` — Route alias added (existing_name, alias_name)
 //! - `alias_removed` — Route alias removed (alias_name)
 //! - `route_scored` — Route score updated (route_name, score)
@@ -79,6 +82,9 @@ pub struct RouteEntry {
     pub paused: bool,
     /// Who last updated this route
     pub updated_by: Address,
+    /// Absolute ledger sequence number after which this route is expired.
+    /// `None` means the route is permanent (no TTL).
+    pub expires_at: Option<u32>,
 }
 
 #[contracttype]
@@ -138,9 +144,18 @@ pub enum RouterError {
     RouteAlreadyExists = 7,
     InvalidRouteName = 8,
     InvalidMetadata = 9,
+    RouteExpired = 10,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
+
+/// Returns `true` if `entry` has a TTL set and the current ledger sequence
+/// number exceeds its expiry ledger. Routes with `expires_at: None` never expire.
+pub(crate) fn is_route_expired(env: &Env, entry: &RouteEntry) -> bool {
+    entry
+        .expires_at
+        .is_some_and(|exp| env.ledger().sequence() > exp)
+}
 
 #[contract]
 pub struct RouterCore;
@@ -225,6 +240,7 @@ impl RouterCore {
             name: name.clone(),
             paused: false,
             updated_by: caller,
+            expires_at: None,
         };
         env.storage()
             .instance()
@@ -254,6 +270,130 @@ impl RouterCore {
         env.events().publish(
             (Symbol::new(&env, "route_registered"),),
             (name.clone(), entry.address.clone()),
+        );
+
+        Ok(())
+    }
+
+    /// Register a new route by name with an optional time-to-live.
+    ///
+    /// Like [`register_route`](Self::register_route), but accepts `ttl_ledgers`
+    /// to make the route expire automatically. If `ttl_ledgers` is `Some(n)`,
+    /// the route's expiry is set to `n` ledgers from the current ledger
+    /// sequence number; once the ledger sequence exceeds that value, [`resolve`](Self::resolve)
+    /// returns [`RouterError::RouteExpired`] and the route is excluded from
+    /// [`get_all_routes`](Self::get_all_routes). If `ttl_ledgers` is `None`, the
+    /// route is permanent, identical to `register_route`.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `caller` - The address initiating the call; must be the admin.
+    /// * `name` - A unique human-readable identifier for the route.
+    /// * `address` - The contract address this route resolves to.
+    /// * `ttl_ledgers` - Number of ledgers from now until expiry, or `None` for no expiry.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`RouterError::Unauthorized`] — if `caller` is not the admin.
+    /// * [`RouterError::RouteAlreadyExists`] — if a route with `name` already exists.
+    /// * [`RouterError::InvalidRouteName`] — if `name` is invalid.
+    /// * [`RouterError::NotInitialized`] — if the contract has not been initialized.
+    pub fn register_route_with_ttl(
+        env: Env,
+        caller: Address,
+        name: String,
+        address: Address,
+        ttl_ledgers: Option<u32>,
+    ) -> Result<(), RouterError> {
+        caller.require_auth();
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
+
+        let expires_at = ttl_ledgers.map(|ttl| env.ledger().sequence().saturating_add(ttl));
+
+        Self::register_route_internal(&env, &caller, name.clone(), address, None, expires_at)?;
+
+        if let Some(exp) = expires_at {
+            env.events().publish(
+                (Symbol::new(&env, router_common::EVENT_ROUTE_TTL_SET),),
+                (name, exp),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Get the expiry ledger sequence number for a route.
+    ///
+    /// Returns `None` if the route does not exist or has no TTL (permanent).
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `name` - The name of the route.
+    ///
+    /// # Returns
+    /// `Some(expiry_ledger)` if the route has a TTL, `None` otherwise.
+    pub fn get_route_expiry(env: Env, name: String) -> Option<u32> {
+        env.storage()
+            .instance()
+            .get::<DataKey, RouteEntry>(&DataKey::Route(name))
+            .and_then(|entry| entry.expires_at)
+    }
+
+    /// Extend the TTL of a route that has not yet expired.
+    ///
+    /// If the route currently has a TTL, the new expiry is `additional_ledgers`
+    /// past its existing expiry (extensions stack). If the route is permanent
+    /// (no TTL set), this gives it a TTL of `additional_ledgers` ledgers from
+    /// now. Caller must be the admin.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `caller` - The address initiating the call; must be the admin.
+    /// * `name` - The name of the route to extend.
+    /// * `additional_ledgers` - Number of ledgers to add to the route's expiry.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`RouterError::Unauthorized`] — if `caller` is not the admin.
+    /// * [`RouterError::RouteNotFound`] — if no route with `name` exists.
+    /// * [`RouterError::RouteExpired`] — if the route has already expired; extend before expiry.
+    /// * [`RouterError::NotInitialized`] — if the contract has not been initialized.
+    pub fn extend_route_ttl(
+        env: Env,
+        caller: Address,
+        name: String,
+        additional_ledgers: u32,
+    ) -> Result<(), RouterError> {
+        caller.require_auth();
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
+
+        let mut entry: RouteEntry = env
+            .storage()
+            .instance()
+            .get(&DataKey::Route(name.clone()))
+            .ok_or(RouterError::RouteNotFound)?;
+
+        if is_route_expired(&env, &entry) {
+            return Err(RouterError::RouteExpired);
+        }
+
+        let current_ledger = env.ledger().sequence();
+        let base = entry.expires_at.unwrap_or(current_ledger);
+        let new_expiry = base.saturating_add(additional_ledgers);
+
+        entry.expires_at = Some(new_expiry);
+        entry.updated_by = caller;
+        env.storage()
+            .instance()
+            .set(&DataKey::Route(name.clone()), &entry);
+
+        env.events().publish(
+            (Symbol::new(&env, router_common::EVENT_ROUTE_TTL_EXTENDED),),
+            (name, new_expiry),
         );
 
         Ok(())
@@ -462,6 +602,7 @@ impl RouterCore {
                     route.name.clone(),
                     route.address.clone(),
                     None,
+                    None,
                 )?;
                 result.record_success(index as u32);
             }
@@ -473,6 +614,7 @@ impl RouterCore {
                     &caller,
                     route.name.clone(),
                     route.address.clone(),
+                    None,
                     None,
                 ) {
                     Ok(()) => result.record_success(idx),
@@ -549,14 +691,15 @@ impl RouterCore {
     /// Resolve a route name to its contract address.
     ///
     /// Looks up the contract address registered under `name`, validates that
-    /// neither the router nor the individual route is paused, increments the
-    /// total-routed counter, and emits a `routed` event. If `name` is an alias,
-    /// resolves to the original route.
+    /// neither the router nor the individual route is paused or expired,
+    /// increments the total-routed counter, and emits a `routed` event. If
+    /// `name` is an alias, resolves to the original route.
     ///
     /// When scored routes exist, score-based selection is applied via a cached
     /// best-route key (maintained on score/pause/removal changes): the
-    /// highest-scoring non-paused route is returned automatically in O(1). If no
-    /// scored, non-paused route exists, falls back to the direct lookup by `name`.
+    /// highest-scoring non-paused, non-expired route is returned automatically
+    /// in O(1). If no scored, eligible route exists, falls back to the direct
+    /// lookup by `name`.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment.
@@ -569,6 +712,7 @@ impl RouterCore {
     /// * [`RouterError::RouterPaused`] — if the entire router is paused.
     /// * [`RouterError::RouteNotFound`] — if no route with `name` exists.
     /// * [`RouterError::RoutePaused`] — if the specific route is paused.
+    /// * [`RouterError::RouteExpired`] — if the route's TTL has lapsed.
     pub fn resolve(env: Env, name: String) -> Result<Address, RouterError> {
         let paused: bool = env
             .storage()
@@ -596,10 +740,23 @@ impl RouterCore {
         // scanning the entire RouteNames vector on every call. If no scored,
         // non-paused route exists, the cache is absent and we fall back to the
         // directly requested route.
+        //
+        // Unlike pausing, TTL expiry is not a write — a route can lapse purely
+        // from ledger time passing with no event to trigger a cache refresh.
+        // So the cached pointer is re-validated against expiry on every read;
+        // if it has gone stale, this call falls back to the requested route
+        // instead of trusting an expired cache entry.
         let final_name = env
             .storage()
             .instance()
             .get::<DataKey, String>(&DataKey::BestRoute)
+            .filter(|best| {
+                env.storage()
+                    .instance()
+                    .get::<DataKey, RouteEntry>(&DataKey::Route(best.clone()))
+                    .map(|e| !is_route_expired(&env, &e))
+                    .unwrap_or(false)
+            })
             .unwrap_or(resolved_name);
 
         let entry: RouteEntry = env
@@ -607,6 +764,14 @@ impl RouterCore {
             .instance()
             .get(&DataKey::Route(final_name.clone()))
             .ok_or(RouterError::RouteNotFound)?;
+
+        if is_route_expired(&env, &entry) {
+            env.events().publish(
+                (Symbol::new(&env, router_common::EVENT_ROUTE_RESOLVE_EXPIRED),),
+                (final_name.clone(),),
+            );
+            return Err(RouterError::RouteExpired);
+        }
 
         if entry.paused {
             env.events().publish(
@@ -1121,17 +1286,30 @@ impl RouterCore {
         Ok(())
     }
 
-    /// Returns all currently registered route names as a vector of strings.
+    /// Returns all currently registered, non-expired route names as a vector of strings.
     ///
-    /// This is a read-only operation. The order of returned names is not guaranteed.
+    /// Routes whose TTL has lapsed are excluded. This is a read-only operation.
+    /// The order of returned names is not guaranteed.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment.
     ///
     /// # Returns
-    /// A `Vec<String>` containing all registered route names.
+    /// A `Vec<String>` containing all registered, non-expired route names.
     pub fn get_all_routes(env: Env) -> Vec<String> {
-        Self::get_route_names(&env)
+        let mut routes = Vec::new(&env);
+        for name in Self::get_route_names(&env).iter() {
+            let expired = env
+                .storage()
+                .instance()
+                .get::<DataKey, RouteEntry>(&DataKey::Route(name.clone()))
+                .map(|e| is_route_expired(&env, &e))
+                .unwrap_or(false);
+            if !expired {
+                routes.push_back(name);
+            }
+        }
+        routes
     }
 
     /// Returns a page of registered route names.
@@ -1244,7 +1422,7 @@ impl RouterCore {
     /// Evaluates each candidate route using a composite score:
     /// `liquidity_score + reliability_score - fee_bps / 10`
     ///
-    /// Routes that are paused or have no score are skipped. Returns the name
+    /// Routes that are paused, expired, or have no score are skipped. Returns the name
     /// of the highest-scoring available route, or `fallback_name` if no
     /// candidate meets `min_score`.
     ///
@@ -1279,11 +1457,11 @@ impl RouterCore {
         let mut best_score: i64 = i64::MIN;
 
         for name in candidates.iter() {
-            // Skip paused routes
+            // Skip paused or expired routes
             let entry: Option<RouteEntry> =
                 env.storage().instance().get(&DataKey::Route(name.clone()));
             let entry = match entry {
-                Some(e) if !e.paused => e,
+                Some(e) if !e.paused && !is_route_expired(&env, &e) => e,
                 _ => continue,
             };
             let _ = entry; // entry validated, not needed further
@@ -1493,6 +1671,7 @@ impl RouterCore {
             RouterError::RouteAlreadyExists => "RouteAlreadyExists",
             RouterError::InvalidRouteName => "InvalidRouteName",
             RouterError::InvalidMetadata => "InvalidMetadata",
+            RouterError::RouteExpired => "RouteExpired",
         }
     }
 
@@ -1502,6 +1681,7 @@ impl RouterCore {
         name: String,
         address: Address,
         metadata: Option<RouteMetadata>,
+        expires_at: Option<u32>,
     ) -> Result<(), RouterError> {
         Self::validate_route_name(env, &name)?;
         if let Some(ref meta) = metadata {
@@ -1513,6 +1693,7 @@ impl RouterCore {
             name: name.clone(),
             paused: false,
             updated_by: caller.clone(),
+            expires_at,
         };
         env.storage()
             .instance()
@@ -1612,7 +1793,7 @@ mod tests {
     extern crate std;
     use super::*;
     use soroban_sdk::{
-        testutils::{Address as _, Events},
+        testutils::{Address as _, Events, Ledger},
         vec, Env, IntoVal, String,
     };
 
@@ -3649,5 +3830,266 @@ mod tests {
             client.try_remove_route_tag(&admin, &missing, &tag),
             Err(Ok(RouterError::RouteNotFound))
         );
+    }
+
+    // ── TTL / expiry tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_register_route_with_ttl_and_resolve_before_expiry() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(100));
+        assert_eq!(client.resolve(&name), addr);
+    }
+
+    #[test]
+    fn test_register_route_with_ttl_none_is_permanent() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "permanent-route");
+        let addr = Address::generate(&env);
+        client.register_route_with_ttl(&admin, &name, &addr, &None);
+        assert_eq!(client.get_route_expiry(&name), None);
+
+        env.ledger().with_mut(|li| li.sequence_number += 1_000_000);
+        assert_eq!(client.resolve(&name), addr);
+    }
+
+    #[test]
+    fn test_register_route_with_ttl_unauthorized() {
+        let (env, _admin, client) = setup();
+        let attacker = Address::generate(&env);
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        let result = client.try_register_route_with_ttl(&attacker, &name, &addr, &Some(10));
+        assert_eq!(result, Err(Ok(RouterError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_register_route_with_ttl_duplicate_fails() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+        let result = client.try_register_route_with_ttl(&admin, &name, &addr, &Some(10));
+        assert_eq!(result, Err(Ok(RouterError::RouteAlreadyExists)));
+    }
+
+    #[test]
+    fn test_get_route_expiry_returns_expected_values() {
+        let (env, admin, client) = setup();
+        let ttl_name = String::from_str(&env, "ttl-route");
+        let permanent_name = String::from_str(&env, "permanent-route");
+        let missing_name = String::from_str(&env, "missing-route");
+        let addr = Address::generate(&env);
+
+        let start = env.ledger().sequence();
+        client.register_route_with_ttl(&admin, &ttl_name, &addr, &Some(50));
+        client.register_route_with_ttl(&admin, &permanent_name, &addr, &None);
+
+        assert_eq!(client.get_route_expiry(&ttl_name), Some(start + 50));
+        assert_eq!(client.get_route_expiry(&permanent_name), None);
+        assert_eq!(client.get_route_expiry(&missing_name), None);
+    }
+
+    #[test]
+    fn test_resolve_fails_after_ttl_expires() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(10));
+
+        env.ledger().with_mut(|li| li.sequence_number += 11);
+
+        let result = client.try_resolve(&name);
+        assert_eq!(result, Err(Ok(RouterError::RouteExpired)));
+    }
+
+    #[test]
+    fn test_resolve_succeeds_at_exact_expiry_ledger_then_fails_after() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+        let start = env.ledger().sequence();
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(10));
+
+        // At exactly the expiry ledger, the route is still valid: expiry is
+        // only crossed once the current ledger *exceeds* it.
+        env.ledger().with_mut(|li| li.sequence_number = start + 10);
+        assert_eq!(client.resolve(&name), addr);
+
+        env.ledger().with_mut(|li| li.sequence_number = start + 11);
+        assert_eq!(client.try_resolve(&name), Err(Ok(RouterError::RouteExpired)));
+    }
+
+    #[test]
+    fn test_resolve_expired_route_emits_event() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(1));
+
+        env.ledger().with_mut(|li| li.sequence_number += 2);
+
+        let _ = client.try_resolve(&name);
+
+        let event = env.events().all().last().unwrap().clone();
+        assert_eq!(
+            event.1,
+            vec![&env, Symbol::new(&env, "route_resolve_expired").into_val(&env)]
+        );
+    }
+
+    #[test]
+    fn test_extend_route_ttl_before_expiry() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+        let start = env.ledger().sequence();
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(10));
+
+        client.extend_route_ttl(&admin, &name, &20);
+        assert_eq!(client.get_route_expiry(&name), Some(start + 30));
+
+        // Would have expired under the original TTL, but the extension covers it.
+        env.ledger().with_mut(|li| li.sequence_number = start + 25);
+        assert_eq!(client.resolve(&name), addr);
+    }
+
+    #[test]
+    fn test_extend_route_ttl_after_expiry_fails() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+        let start = env.ledger().sequence();
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(10));
+
+        env.ledger().with_mut(|li| li.sequence_number = start + 11);
+
+        let result = client.try_extend_route_ttl(&admin, &name, &20);
+        assert_eq!(result, Err(Ok(RouterError::RouteExpired)));
+    }
+
+    #[test]
+    fn test_extend_route_ttl_on_permanent_route_sets_new_ttl() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        client.register_route(&admin, &name, &addr, &None);
+        assert_eq!(client.get_route_expiry(&name), None);
+
+        let now = env.ledger().sequence();
+        client.extend_route_ttl(&admin, &name, &15);
+        assert_eq!(client.get_route_expiry(&name), Some(now + 15));
+    }
+
+    #[test]
+    fn test_extend_route_ttl_route_not_found() {
+        let (env, admin, client) = setup();
+        let missing = String::from_str(&env, "missing");
+        let result = client.try_extend_route_ttl(&admin, &missing, &10);
+        assert_eq!(result, Err(Ok(RouterError::RouteNotFound)));
+    }
+
+    #[test]
+    fn test_extend_route_ttl_unauthorized() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "oracle");
+        let addr = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(10));
+
+        let result = client.try_extend_route_ttl(&attacker, &name, &5);
+        assert_eq!(result, Err(Ok(RouterError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_route_ttl_set_event_emitted() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(10));
+
+        let found = env.events().all().iter().any(|e| {
+            e.1.get(0)
+                .map(|v| {
+                    let s: Symbol = v.into_val(&env);
+                    s == Symbol::new(&env, "route_ttl_set")
+                })
+                .unwrap_or(false)
+        });
+        assert!(found);
+    }
+
+    #[test]
+    fn test_route_ttl_extended_event_emitted() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "temp-route");
+        let addr = Address::generate(&env);
+        client.register_route_with_ttl(&admin, &name, &addr, &Some(10));
+
+        let events_before = env.events().all().len();
+        client.extend_route_ttl(&admin, &name, &5);
+        let events_after = env.events().all().len();
+        assert_eq!(events_after, events_before + 1);
+
+        let event = env.events().all().last().unwrap().clone();
+        assert_eq!(
+            event.1,
+            vec![&env, Symbol::new(&env, "route_ttl_extended").into_val(&env)]
+        );
+    }
+
+    #[test]
+    fn test_get_all_routes_excludes_expired() {
+        let (env, admin, client) = setup();
+        let temp = String::from_str(&env, "temp-route");
+        let permanent = String::from_str(&env, "permanent-route");
+        let addr = Address::generate(&env);
+
+        client.register_route_with_ttl(&admin, &temp, &addr, &Some(5));
+        client.register_route(&admin, &permanent, &addr, &None);
+
+        let routes = client.get_all_routes();
+        assert_eq!(routes.len(), 2);
+
+        env.ledger().with_mut(|li| li.sequence_number += 6);
+
+        let routes = client.get_all_routes();
+        assert_eq!(routes.len(), 1);
+        assert!(routes.contains(&permanent));
+        assert!(!routes.contains(&temp));
+    }
+
+    #[test]
+    fn test_resolve_falls_back_when_cached_best_route_expires() {
+        let (env, admin, client) = setup();
+        let scored = String::from_str(&env, "scored-route");
+        let other = String::from_str(&env, "other-route");
+        let addr1 = Address::generate(&env);
+        let addr2 = Address::generate(&env);
+
+        client.register_route_with_ttl(&admin, &scored, &addr1, &Some(5));
+        client.register_route(&admin, &other, &addr2, &None);
+
+        client.set_route_score(
+            &admin,
+            &scored,
+            &RouteScore {
+                liquidity_score: 80,
+                fee_bps: 10,
+                reliability_score: 90,
+            },
+        );
+
+        // The scored route is cached as best and wins resolution regardless of
+        // the requested name, per the existing score-based selection behavior.
+        assert_eq!(client.resolve(&other), addr1);
+
+        // Once it expires, the stale cache must not poison resolution for
+        // unrelated routes: this call should fall back to the requested route.
+        env.ledger().with_mut(|li| li.sequence_number += 6);
+        assert_eq!(client.resolve(&other), addr2);
     }
 }

--- a/contracts/router-core/src/scoring.rs
+++ b/contracts/router-core/src/scoring.rs
@@ -6,7 +6,7 @@
 
 use soroban_sdk::{Env, String, Symbol};
 
-use crate::{DataKey, RouteEntry, RouteScore};
+use crate::{is_route_expired, DataKey, RouteEntry, RouteScore};
 
 /// Recompute and cache the highest-scoring, non-paused route.
 ///
@@ -25,13 +25,13 @@ pub fn recompute_best_route(env: &Env) {
     let mut best_score: i64 = i64::MIN;
 
     for name in names.iter() {
-        // Skip missing or paused routes
+        // Skip missing, paused, or expired routes
         match env
             .storage()
             .instance()
             .get::<DataKey, RouteEntry>(&DataKey::Route(name.clone()))
         {
-            Some(e) if !e.paused => {}
+            Some(e) if !e.paused && !is_route_expired(env, &e) => {}
             _ => continue,
         }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,6 +23,7 @@ different things depending on which contract returned it.
 | `RouteAlreadyExists` | 7 | Registering a route or alias with a name that is already in use. | Choose a unique name or update/remove the existing route first. |
 | `InvalidRouteName` | 8 | A route name is empty or only whitespace. | Send a non-empty, trimmed route name. |
 | `InvalidMetadata` | 9 | Route metadata exceeds limits: description over 256 characters or more than 5 tags. | Shorten the description or reduce the tag list before submitting. |
+| `RouteExpired` | 10 | `resolve` targets a route whose TTL ledger has been exceeded, or `extend_route_ttl` targets a route that has already expired. | Re-register the route, or call `extend_route_ttl` before expiry next time. |
 
 ### router-registry `RegistryError`
 
@@ -129,6 +130,30 @@ Updates an existing route to point to a new address. Emits `route_updated` and `
 
 ---
 
+### `register_route_with_ttl(caller, name, address, ttl_ledgers: Option<u32>) → Result<(), RouterError>`
+Registers a new route like `register_route`, but with an optional time-to-live. When `ttl_ledgers` is `Some(n)`, the route expires `n` ledgers from the current ledger sequence number; `resolve` then returns `RouteExpired` and `get_all_routes` excludes it. `None` registers a permanent route, identical to `register_route`.
+
+**Errors:** `Unauthorized`, `RouteAlreadyExists`, `NotInitialized`, `InvalidRouteName`
+
+```bash
+stellar contract invoke --id <CORE_ID> --network testnet --source admin \
+  -- register_route_with_ttl --caller <ADMIN> --name beta-integration --address <CONTRACT_ID> --ttl_ledgers 100000
+```
+
+---
+
+### `get_route_expiry(name) → Option<u32>`
+Returns the expiry ledger sequence number for `name`, or `None` if the route does not exist or has no TTL (permanent).
+
+---
+
+### `extend_route_ttl(caller, name, additional_ledgers: u32) → Result<(), RouterError>`
+Extends a route's TTL by `additional_ledgers`. If the route already has a TTL, the new expiry stacks on top of the existing one; if the route is permanent, it gains a TTL of `additional_ledgers` ledgers from now. Must be called before the route expires.
+
+**Errors:** `Unauthorized`, `RouteNotFound`, `RouteExpired` (route has already lapsed), `NotInitialized`
+
+---
+
 ### `remove_route(caller, name) → Result<(), RouterError>`
 Deletes a route and removes any aliases pointing to it.
 
@@ -139,7 +164,7 @@ Deletes a route and removes any aliases pointing to it.
 ### `resolve(name) → Result<Address, RouterError>`
 Resolves a route name (or alias) to its contract address. Increments `total_routed`.
 
-**Errors:** `RouterPaused`, `RouteNotFound`, `RoutePaused`
+**Errors:** `RouterPaused`, `RouteNotFound`, `RoutePaused`, `RouteExpired` (TTL ledger exceeded)
 
 ```bash
 stellar contract invoke --id <CORE_ID> --network testnet --source any \
@@ -168,7 +193,7 @@ Returns the full `RouteEntry` for `name`, or `None` if not registered.
 ---
 
 ### `get_all_routes() → Vec<String>`
-Returns all registered route names.
+Returns all registered, non-expired route names. Routes whose TTL has lapsed are excluded.
 
 ---
 
@@ -805,6 +830,7 @@ Each contract defines its own `#[contracterror]` enum. Use the tables below as t
 | `RouteAlreadyExists` | `7` | Registering route or alias that conflicts with existing route/alias | Use a unique name, or update/remove existing entry first |
 | `InvalidRouteName` | `8` | Route name is empty or whitespace-only | Validate/sanitize names client-side before submit |
 | `InvalidMetadata` | `9` | Route metadata exceeds constraints (description/tags limits) | Trim metadata to allowed bounds, then retry |
+| `RouteExpired` | `10` | `resolve` is called for a route whose TTL ledger has been exceeded, or `extend_route_ttl` is called on an already-expired route | Re-register the route, or extend its TTL before it lapses |
 
 ### router-registry (`RegistryError`)
 


### PR DESCRIPTION
## Summary
- Adds `register_route_with_ttl`, `get_route_expiry`, and `extend_route_ttl` so routes can optionally expire after a number of ledgers.
- `resolve()` returns `RouteExpired` once the current ledger exceeds a route's expiry; `get_all_routes()` excludes expired routes. Routes registered without a TTL remain permanent (unchanged behavior).
- Fixes a latent issue the cached best-route selector would otherwise have: an expired scored route could poison `resolve()` for unrelated routes between cache refreshes, since expiry (unlike pause/score/removal) isn't a write that triggers a cache recompute. `resolve()` now re-validates the cached pointer against expiry on every read.

Closes #571