### PR TITLE
feat(router-timelock): add min_delay update function for admin

### DIFF
--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -178,6 +178,9 @@ pub const EVENT_OP_CANCELLED: &str = "op_cancelled";
 /// Standard event topic for timelock operation description updates
 pub const EVENT_OP_DESCRIPTION_UPDATED: &str = "op_description_updated";
 
+/// Standard event topic for timelock minimum delay updates
+pub const EVENT_MIN_DELAY_UPDATED: &str = "min_delay_updated";
+
 /// Standard event topic for contract registration in registry
 pub const EVENT_CONTRACT_REGISTERED: &str = "contract_registered";
 

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -12,6 +12,7 @@
 //! - `op_executed`            — Operation executed (op_id, target)
 //! - `op_cancelled`           — Operation cancelled (op_id)
 //! - `op_description_updated` — Operation description updated (op_id, new_description)
+//! - `min_delay_updated`      — Minimum delay updated (old_min_delay, new_min_delay)
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, Env, String,
@@ -388,6 +389,40 @@ impl RouterTimelock {
             .instance()
             .get(&DataKey::MinDelay)
             .unwrap_or(0)
+    }
+
+    /// Update the minimum delay (seconds) required for newly queued operations.
+    ///
+    /// Only the admin may call this. The new value only applies to operations
+    /// queued after this call — already-queued operations keep the `eta` that
+    /// was computed from the delay in effect when they were queued, so this
+    /// cannot be used to accelerate or stall operations already in the queue.
+    ///
+    /// Emits `min_delay_updated` with `(old_min_delay, new_min_delay)`.
+    pub fn set_min_delay(
+        env: Env,
+        caller: Address,
+        new_min_delay: u64,
+    ) -> Result<(), TimelockError> {
+        caller.require_auth();
+        Self::require_admin(&env, &caller)?;
+
+        let old_min_delay: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinDelay)
+            .ok_or(TimelockError::NotInitialized)?;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MinDelay, &new_min_delay);
+
+        env.events().publish(
+            (Symbol::new(&env, router_common::EVENT_MIN_DELAY_UPDATED),),
+            (old_min_delay, new_min_delay),
+        );
+
+        Ok(())
     }
 
     /// Get the admin.
@@ -945,6 +980,77 @@ mod tests {
             client.try_queue(&admin, &desc, &target, &3600, &GRACE, &deps),
             Err(Ok(TimelockError::Unauthorized))
         );
+    }
+
+    // ── set_min_delay ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_min_delay_updates_value() {
+        let (_env, admin, client) = setup();
+        client.set_min_delay(&admin, &7200);
+        assert_eq!(client.min_delay(), 7200);
+    }
+
+    #[test]
+    fn test_set_min_delay_emits_event() {
+        let (env, admin, client) = setup();
+        client.set_min_delay(&admin, &7200);
+
+        let events = env.events().all();
+        let last = events.last().unwrap();
+        let topic: Symbol = last.1.get(0).unwrap().into_val(&env);
+        assert_eq!(topic, Symbol::new(&env, router_common::EVENT_MIN_DELAY_UPDATED));
+
+        let (old, new): (u64, u64) = last.2.into_val(&env);
+        assert_eq!(old, 3600);
+        assert_eq!(new, 7200);
+    }
+
+    #[test]
+    fn test_set_min_delay_unauthorized_fails() {
+        let (env, _admin, client) = setup();
+        let attacker = Address::generate(&env);
+        let result = client.try_set_min_delay(&attacker, &7200);
+        assert_eq!(result, Err(Ok(TimelockError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_set_min_delay_does_not_affect_already_queued_ops() {
+        // Operations queued before a min_delay change keep the eta computed
+        // from the delay that was in effect at queue time.
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &3600, &GRACE, &deps);
+        let op_before = client.get_op(&op_id).unwrap();
+
+        // Raise min_delay well above the original queued delay.
+        client.set_min_delay(&admin, &100_000);
+
+        let op_after = client.get_op(&op_id).unwrap();
+        assert_eq!(op_before.eta, op_after.eta);
+
+        // The op still becomes executable at its original eta, unaffected
+        // by the new (higher) min_delay.
+        env.ledger().with_mut(|l| l.timestamp += 3601);
+        client.execute(&admin, &op_id);
+        assert!(client.get_op(&op_id).unwrap().executed);
+    }
+
+    #[test]
+    fn test_set_min_delay_applies_to_newly_queued_ops() {
+        let (env, admin, client) = setup();
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps = Vec::new(&env);
+
+        client.set_min_delay(&admin, &7200);
+
+        // A delay below the new min_delay (but above the old one) must fail.
+        let result = client.try_queue(&admin, &desc, &target, &3600, &GRACE, &deps);
+        assert_eq!(result, Err(Ok(TimelockError::DelayTooShort)));
     }
 
     // ── Issue #586: pending ops index and count_by_status ─────────────────────


### PR DESCRIPTION
## Summary
- Adds `set_min_delay(env, caller, new_min_delay) -> Result<(), TimelockError>` to `router-timelock`, gated to the contract admin.
- Already-queued operations are unaffected: `eta` is computed and stored at `queue()` time from whatever `min_delay` was in effect then, and `execute()`/`get_operation_status()` never re-read `min_delay`, so raising or lowering it cannot retroactively accelerate or stall in-flight operations.
- Emits a new `min_delay_updated` event `(old_min_delay, new_min_delay)` for the audit trail (added `EVENT_MIN_DELAY_UPDATED` to `router-common`).

## Design notes
- Went with a direct admin-gated setter rather than self-referential timelocking (queuing the delay change through the timelock itself). That's a legitimate follow-up hardening step mentioned in the issue, but it's a separate architectural change (the timelock would need to be able to target its own `min_delay` storage key as an "operation") that felt out of scope for this addition — happy to follow up if maintainers want it.

## Test plan
- [x] `cargo test -p router-timelock` — all tests pass, including 5 new tests covering: value update, event emission, unauthorized rejection, that already-queued ops keep their original `eta`/executability, and that the new minimum applies to subsequently queued ops.
- [x] `cargo clippy -p router-timelock -p router-common -- -D warnings` clean.
- [x] `cargo check --workspace` clean.

Closes #663