### PR TITLE
ci: integration tests silently pass on failure due to continue-on-error: true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,6 @@ jobs:
         run: cargo test --test integration_tests -- --ignored --test-threads=1 --nocapture
         env:
           STELLAR_RPC_URL: https://soroban-testnet.stellar.org
-        continue-on-error: true
 
       - name: Upload integration test results
         if: always()


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from the "Run integration tests" step in the `integration-test` job of `.github/workflows/ci.yml`.
- With it set, a failing integration test run against testnet would still report the step (and the job) as successful, so regressions against the live network went unnoticed.

## Note for maintainers
While investigating this, I noticed `.github/workflows/ci.yml` currently defines two jobs both keyed `storage-profiling:` (one building/uploading WASM artifacts, the other running `scripts/profile-storage.sh`). GitHub Actions rejects the whole workflow file for duplicate job IDs, which is why recent runs on `main` fail immediately with "workflow file issue" before any step even executes. That's a separate, pre-existing problem unrelated to this issue's `continue-on-error` flag, so I left it out of this PR — flagging it here in case maintainers want a follow-up issue/PR to fix the job naming.

## Test plan
- [x] Confirmed the diff is a single-line removal, no other changes to the workflow.
- [x] Validated the YAML still parses (aside from the pre-existing duplicate-key issue noted above, which is unchanged by this PR).
- Once the duplicate-job-key issue is separately resolved, this change will cause genuine integration test failures to fail the `integration-test` job/pipeline going forward.

Closes #657