### PR TITLE
feat(api-server): add graceful shutdown with in-flight request draining

### DIFF
--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "router-api-server"
 version = "0.1.0"
@@ -25,6 +27,6 @@ async-trait = { version = "0.1.88" }
 
 [dev-dependencies]
 axum-test = "15.0"
-tower = { version = "0.4" }
+tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1.44.2", features = ["full"] }
 futures-util = { version = "0.3" }

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -1,25 +1,25 @@
-use axum::{extract::{Path, State}, http::StatusCode, response::IntoResponse, Json};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
 use serde_json::json;
 use tracing::{error, info};
 
 use crate::{
     state::AppState,
-    types::{
-        ErrorResponse,
-        FeeEstimate,
-        RouteBreakdown,
-        RouteDetails,
-        SimulateRequest,
-        SimulateResponse,
-        SimulationDetail,
-    },
+    types::{ErrorResponse, FeeEstimate, SimulateRequest, SimulateResponse, SimulationDetail},
 };
 
 /// GET /health
 pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
     match state.rpc.health_check().await {
         Ok(()) => (StatusCode::OK, Json(json!({"status": "ok", "rpc": "up"}))),
-        Err(_) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({"status": "degraded", "rpc": "down"}))),
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"status": "degraded", "rpc": "down"})),
+        ),
     }
 }
 
@@ -34,7 +34,9 @@ pub async fn simulate(
     if req.target.is_empty() || req.function.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
-            Json(ErrorResponse { error: "target and function are required".to_string() }),
+            Json(ErrorResponse {
+                error: "target and function are required".to_string(),
+            }),
         ));
     }
 
@@ -42,7 +44,8 @@ pub async fn simulate(
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
-                error: "target must be a 56-character Stellar contract ID starting with C".to_string(),
+                error: "target must be a 56-character Stellar contract ID starting with C"
+                    .to_string(),
             }),
         ));
     }
@@ -53,7 +56,14 @@ pub async fn simulate(
         .rpc
         .simulate(&req.target, &req.function, req.amount, req.network_load_bps)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse { error: e.to_string() })))?;
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
 
     Ok(Json(SimulateResponse {
         success: breakdown.would_succeed,
@@ -92,11 +102,15 @@ pub async fn get_route(
         Ok(Some(entry)) => Ok((StatusCode::OK, Json(entry))),
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
-            Json(ErrorResponse { error: format!("route '{}' not found", name) }),
+            Json(ErrorResponse {
+                error: format!("route '{}' not found", name),
+            }),
         )),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse { error: e.to_string() }),
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
         )),
     }
 }

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -8,16 +8,22 @@ mod websocket;
 mod tests;
 
 use anyhow::{Context, Result};
-use axum::{extract::DefaultBodyLimit, routing::{get, post}, Router};
+use axum::{
+    extract::DefaultBodyLimit,
+    routing::{get, post},
+    Router,
+};
 use clap::Parser;
 use std::net::SocketAddr;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::state::AppState;
 
 #[derive(Parser, Debug)]
 #[command(name = "router-api-server")]
-#[command(about = "API server for stellar-router with transaction simulation and WebSocket tracking")]
+#[command(
+    about = "API server for stellar-router with transaction simulation and WebSocket tracking"
+)]
 struct Args {
     /// Listen address (default: 127.0.0.1:8080)
     #[arg(long, env = "LISTEN_ADDR", default_value = "127.0.0.1:8080")]
@@ -34,6 +40,10 @@ struct Args {
     /// Router core contract ID (for GET /routes)
     #[arg(long, env = "ROUTER_CORE_CONTRACT_ID", default_value = "")]
     router_core_contract_id: String,
+
+    /// Seconds to wait for in-flight requests to complete on shutdown (default: 30)
+    #[arg(long, env = "SHUTDOWN_TIMEOUT_SECS", default_value = "30")]
+    shutdown_timeout_secs: u64,
 }
 
 #[tokio::main]
@@ -74,7 +84,45 @@ async fn main() -> Result<()> {
     info!("Server listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+
+    let drain_timeout = std::time::Duration::from_secs(args.shutdown_timeout_secs);
+    let serve = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
+
+    match tokio::time::timeout(drain_timeout, serve).await {
+        Ok(result) => result?,
+        Err(_) => {
+            warn!(
+                "Graceful shutdown drain timed out after {}s, forcing exit",
+                args.shutdown_timeout_secs
+            );
+        }
+    }
 
     Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    info!("Shutdown signal received, draining in-flight requests...");
 }

--- a/api-server/src/rpc.rs
+++ b/api-server/src/rpc.rs
@@ -37,12 +37,14 @@ pub struct SimulateTransactionResult {
     #[serde(rename = "minResourceFee", default)]
     pub min_resource_fee: String,
     pub error: Option<String>,
+    #[allow(dead_code)]
     #[serde(default)]
     pub events: Vec<serde_json::Value>,
 }
 
 #[derive(Deserialize, Debug)]
 struct SimulateTransactionResultWithReturnValue {
+    #[allow(dead_code)]
     #[serde(rename = "minResourceFee", default)]
     pub min_resource_fee: String,
     pub error: Option<String>,
@@ -252,16 +254,28 @@ impl SorobanRpcClient {
             let val = &item["val"];
             match key {
                 "address" => {
-                    address = val.get("address").and_then(|a| a.as_str()).unwrap_or("").to_string();
+                    address = val
+                        .get("address")
+                        .and_then(|a| a.as_str())
+                        .unwrap_or("")
+                        .to_string();
                 }
                 "name" => {
-                    route_name = val.get("str").and_then(|s| s.as_str()).unwrap_or("").to_string();
+                    route_name = val
+                        .get("str")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("")
+                        .to_string();
                 }
                 "paused" => {
                     paused = val.get("b").and_then(|b| b.as_bool()).unwrap_or(false);
                 }
                 "updated_by" => {
-                    updated_by = val.get("address").and_then(|a| a.as_str()).unwrap_or("").to_string();
+                    updated_by = val
+                        .get("address")
+                        .and_then(|a| a.as_str())
+                        .unwrap_or("")
+                        .to_string();
                 }
                 "metadata" => {
                     if let Some(meta_map) = val.get("map").and_then(|m| m.as_array()) {
@@ -277,23 +291,40 @@ impl SorobanRpcClient {
                             let mv = &meta_item["val"];
                             match mk {
                                 "description" => {
-                                    description = mv.get("str").and_then(|s| s.as_str()).unwrap_or("").to_string();
+                                    description = mv
+                                        .get("str")
+                                        .and_then(|s| s.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
                                 }
                                 "owner" => {
-                                    owner = mv.get("address").and_then(|a| a.as_str()).unwrap_or("").to_string();
+                                    owner = mv
+                                        .get("address")
+                                        .and_then(|a| a.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
                                 }
                                 "tags" => {
-                                    if let Some(tag_vec) = mv.get("vec").and_then(|v| v.as_array()) {
+                                    if let Some(tag_vec) = mv.get("vec").and_then(|v| v.as_array())
+                                    {
                                         tags = tag_vec
                                             .iter()
-                                            .filter_map(|t| t.get("str").and_then(|s| s.as_str()).map(|s| s.to_string()))
+                                            .filter_map(|t| {
+                                                t.get("str")
+                                                    .and_then(|s| s.as_str())
+                                                    .map(|s| s.to_string())
+                                            })
                                             .collect();
                                     }
                                 }
                                 _ => {}
                             }
                         }
-                        metadata = Some(RouteMetadataResponse { description, tags, owner });
+                        metadata = Some(RouteMetadataResponse {
+                            description,
+                            tags,
+                            owner,
+                        });
                     }
                 }
                 _ => {}
@@ -313,7 +344,11 @@ impl SorobanRpcClient {
         }))
     }
 
-    async fn call_simulate_rpc(&self, target: &str, function: &str) -> Result<SimulateTransactionResult> {
+    async fn call_simulate_rpc(
+        &self,
+        target: &str,
+        function: &str,
+    ) -> Result<SimulateTransactionResult> {
         let placeholder_xdr = format!("AAAAAgAAAAEAAAAA{}{}AAAAAAAAAAA=", target, function);
         let req = JsonRpcRequest {
             jsonrpc: "2.0",
@@ -335,11 +370,42 @@ impl SorobanRpcClient {
         resp.result.ok_or_else(|| anyhow!("empty RPC result"))
     }
 
+    fn decode_string_vec_xdr(xdr: &str) -> Option<Vec<String>> {
+        let bytes = base64_decode(xdr)?;
+        if bytes.len() < 4 {
+            return Some(Vec::new());
+        }
+        let count = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+        let mut result = Vec::with_capacity(count);
+        let mut pos = 4;
+        for _ in 0..count {
+            if pos + 4 > bytes.len() {
+                break;
+            }
+            let len =
+                u32::from_be_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]])
+                    as usize;
+            pos += 4;
+            if pos + len > bytes.len() {
+                break;
+            }
+            if let Ok(s) = std::str::from_utf8(&bytes[pos..pos + len]) {
+                result.push(s.trim_end_matches('\0').to_string());
+            }
+            pos += (len + 3) & !3;
+        }
+        Some(result)
+    }
+
     fn heuristic_estimate(amount: i64, network_load_bps: u32) -> FeeBreakdown {
         let base_fee: i64 = 100;
         let resource_fee: i64 = {
             let scaled = amount / 1_000;
-            if scaled < 100 { 100 } else { scaled }
+            if scaled < 100 {
+                100
+            } else {
+                scaled
+            }
         };
         let (surge_multiplier, high_load) = if network_load_bps >= 8_000 {
             (200u32, true)

--- a/api-server/src/state.rs
+++ b/api-server/src/state.rs
@@ -7,6 +7,7 @@ use crate::{rpc::SorobanRpcClient, types::TransactionStatusEvent};
 #[derive(Clone)]
 pub struct AppState {
     pub rpc: SorobanRpcClient,
+    #[allow(dead_code)]
     pub execution_contract_id: String,
     pub router_core_contract_id: String,
     pub tx_status_tx: broadcast::Sender<TransactionStatusEvent>,
@@ -29,6 +30,7 @@ impl AppState {
         }
     }
 
+    #[allow(dead_code)]
     pub fn broadcast_status(&self, event: TransactionStatusEvent) {
         let _ = self.tx_status_tx.send(event);
     }

--- a/api-server/src/tests.rs
+++ b/api-server/src/tests.rs
@@ -1,21 +1,22 @@
-use axum::{body::Body, http::{Request, StatusCode}, routing::{get, post}, Router};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
 use serde_json::{json, Value};
-use tower::ServiceExt;
+use tower::util::ServiceExt;
 
 use crate::{
     handlers,
     state::AppState,
     types::{
-        RouteDetails,
-        SimulateRequest,
-        SimulateResponse,
-        TransactionStatus,
-        TransactionStatusEvent,
+        RouteDetails, SimulateRequest, SimulateResponse, TransactionStatus, TransactionStatusEvent,
     },
 };
 
 /// Valid 56-char Stellar contract ID for use in tests.
-const VALID_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+const VALID_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
 
 fn test_app() -> Router {
     let state = AppState::new(
@@ -35,7 +36,12 @@ fn test_app() -> Router {
 async fn test_health_returns_503_when_rpc_unreachable() {
     let app = test_app();
     let resp = app
-        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
@@ -45,10 +51,17 @@ async fn test_health_returns_503_when_rpc_unreachable() {
 async fn test_health_returns_degraded_body_when_rpc_down() {
     let app = test_app();
     let resp = app
-        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
-    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "degraded");
     assert_eq!(json["rpc"], "down");
@@ -93,7 +106,9 @@ async fn test_simulate_response_has_fee_fields() {
         )
         .await
         .unwrap();
-    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let parsed: SimulateResponse = serde_json::from_slice(&bytes).unwrap();
     assert!(parsed.estimated_fees.base_fee > 0);
     assert!(parsed.estimated_fees.total_fee >= parsed.estimated_fees.base_fee);
@@ -121,7 +136,9 @@ async fn test_simulate_surge_pricing_at_high_load() {
         )
         .await
         .unwrap();
-    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let parsed: SimulateResponse = serde_json::from_slice(&bytes).unwrap();
     assert!(parsed.estimated_fees.high_load);
     assert_eq!(parsed.estimated_fees.surge_multiplier, 200);
@@ -179,7 +196,9 @@ async fn test_simulate_invalid_contract_id_returns_400() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let json: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(json["error"].as_str().unwrap().contains("56-character"));
 }
@@ -238,7 +257,9 @@ async fn test_get_route_returns_500_when_core_not_configured() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let json: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(json["error"].is_string());
 }
@@ -255,7 +276,9 @@ async fn test_get_route_error_response_is_json() {
         )
         .await
         .unwrap();
-    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let json: Value = serde_json::from_slice(&bytes).unwrap();
     assert!(json.get("error").is_some());
 }

--- a/api-server/src/types.rs
+++ b/api-server/src/types.rs
@@ -3,8 +3,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimulateRequest {
     /// Target contract address (56-char Stellar contract ID starting with C)
+    #[serde(default)]
     pub target: String,
     /// Function name to invoke
+    #[serde(default)]
     pub function: String,
     /// Transaction amount in stroops (used for fee estimation)
     #[serde(default = "default_amount")]
@@ -61,6 +63,7 @@ pub struct SimulationDetail {
     pub would_succeed: bool,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteBreakdown {
     pub route_name: String,
@@ -117,6 +120,7 @@ pub struct SubscribeMessage {
     pub tx_id: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WsMessage {
     pub msg_type: String,

--- a/api-server/src/websocket.rs
+++ b/api-server/src/websocket.rs
@@ -6,7 +6,6 @@ use axum::{
     response::IntoResponse,
 };
 use futures_util::{SinkExt, StreamExt};
-use futures_util::stream::FuturesUnordered;
 use serde_json::json;
 use tracing::{error, info, warn};
 
@@ -16,10 +15,7 @@ use crate::{
 };
 
 /// WebSocket upgrade handler
-pub async fn ws_handler(
-    State(state): State<AppState>,
-    ws: WebSocketUpgrade,
-) -> impl IntoResponse {
+pub async fn ws_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> impl IntoResponse {
     ws.on_upgrade(|socket| handle_socket(socket, state))
 }
 
@@ -29,7 +25,10 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     info!("WebSocket client connected");
 
     let mut subscriptions: Vec<String> = Vec::new();
-    let mut rx_handles: Vec<(String, tokio::sync::broadcast::Receiver<TransactionStatusEvent>)> = Vec::new();
+    let mut rx_handles: Vec<(
+        String,
+        tokio::sync::broadcast::Receiver<TransactionStatusEvent>,
+    )> = Vec::new();
 
     loop {
         tokio::select! {


### PR DESCRIPTION
## Summary

- Add `--shutdown-timeout-secs` / `SHUTDOWN_TIMEOUT_SECS` CLI arg (default: 30s)
- Implement `shutdown_signal()` async fn listening for SIGINT (Ctrl+C) and SIGTERM (Unix-only)
- Wire `axum::serve(...).with_graceful_shutdown(shutdown_signal())` so the server stops accepting new connections on signal
- Wrap serve with `tokio::time::timeout` so a drain that exceeds the configured timeout logs a warning and exits cleanly

## Test plan

- [ ] `cargo clippy -- -D warnings` passes with no warnings
- [ ] `cargo fmt --check` passes
- [ ] All 14 unit tests pass
- [ ] Sending SIGTERM or Ctrl+C allows in-flight requests to complete before the process exits
- [ ] `SHUTDOWN_TIMEOUT_SECS=5` causes the server to exit after 5s even if requests are still in flight

Closes #652