### PR TITLE
fix/feat: resolve issues #735 #737 #738 #741

### DIFF
--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -12,7 +12,6 @@ use crate::{
     types::{
         ErrorCode, ErrorResponse, FeeEstimate, SimulateRequest, SimulateResponse, SimulationDetail,
     },
-    types::{ErrorResponse, FeeEstimate, SimulateRequest, SimulateResponse, SimulationDetail},
 };
 
 /// GET /health
@@ -42,9 +41,6 @@ pub async fn simulate(
                 "target and function are required",
                 "target",
             )),
-            Json(ErrorResponse {
-                error: "target and function are required".to_string(),
-            }),
         ));
     }
 
@@ -56,10 +52,6 @@ pub async fn simulate(
                 "target must be a 56-character Stellar contract ID starting with C",
                 "target",
             )),
-            Json(ErrorResponse {
-                error: "target must be a 56-character Stellar contract ID starting with C"
-                    .to_string(),
-            }),
         ));
     }
 
@@ -73,9 +65,6 @@ pub async fn simulate(
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(ErrorCode::RpcError, e.to_string())),
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
             )
         })?;
 
@@ -122,23 +111,7 @@ pub async fn get_route(
         )),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                ErrorCode::NotFound,
-                format!("route '{}' not found", name),
-            )),
-        )),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::new(ErrorCode::RpcError, e.to_string())),
-            Json(ErrorResponse {
-                error: format!("route '{}' not found", name),
-            }),
-        )),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
         )),
     }
 }

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -17,7 +17,6 @@ use axum::{
 use clap::Parser;
 use std::net::SocketAddr;
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tracing::info;
 use tracing::{info, warn};
 
 use crate::state::AppState;
@@ -130,6 +129,8 @@ fn build_cors_layer(origins: &[String]) -> CorsLayer {
         .allow_origin(allow_origin)
         .allow_methods(allow_methods)
         .allow_headers(allow_headers)
+}
+
 async fn shutdown_signal() {
     let ctrl_c = async {
         tokio::signal::ctrl_c()

--- a/api-server/src/state.rs
+++ b/api-server/src/state.rs
@@ -1,8 +1,14 @@
 use dashmap::DashMap;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use tokio::sync::broadcast;
 
 use crate::{rpc::SorobanRpcClient, types::TransactionStatusEvent};
+
+pub const MAX_WS_CONNECTIONS: usize = 100;
+pub const MAX_SUBSCRIPTIONS_PER_CONNECTION: usize = 100;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -12,6 +18,7 @@ pub struct AppState {
     pub router_core_contract_id: String,
     pub tx_status_tx: broadcast::Sender<TransactionStatusEvent>,
     pub tx_subscribers: Arc<DashMap<String, usize>>,
+    pub ws_connection_count: Arc<AtomicUsize>,
 }
 
 impl AppState {
@@ -27,6 +34,7 @@ impl AppState {
             router_core_contract_id,
             tx_status_tx,
             tx_subscribers: Arc::new(DashMap::new()),
+            ws_connection_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -51,5 +59,22 @@ impl AppState {
                 self.tx_subscribers.remove(tx_id);
             }
         }
+    }
+
+    /// Returns true if a new connection was accepted, false if the limit is reached.
+    pub fn try_acquire_ws_connection(&self) -> bool {
+        self.ws_connection_count
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                if current < MAX_WS_CONNECTIONS {
+                    Some(current + 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok()
+    }
+
+    pub fn release_ws_connection(&self) {
+        self.ws_connection_count.fetch_sub(1, Ordering::SeqCst);
     }
 }

--- a/api-server/src/websocket.rs
+++ b/api-server/src/websocket.rs
@@ -7,16 +7,30 @@ use axum::{
 };
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
+use std::time::Duration;
 use tracing::{error, info, warn};
 
 use crate::{
-    state::AppState,
+    state::{AppState, MAX_SUBSCRIPTIONS_PER_CONNECTION},
     types::{SubscribeMessage, TransactionStatusEvent},
 };
 
+const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
 /// WebSocket upgrade handler
 pub async fn ws_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> impl IntoResponse {
+    if !state.try_acquire_ws_connection() {
+        return ws
+            .on_upgrade(|mut socket| async move {
+                let msg = json!({"error": "connection limit reached"}).to_string();
+                let _ = socket.send(Message::Text(msg)).await;
+                let _ = socket.close().await;
+            })
+            .into_response();
+    }
     ws.on_upgrade(|socket| handle_socket(socket, state))
+        .into_response()
 }
 
 async fn handle_socket(socket: WebSocket, state: AppState) {
@@ -29,32 +43,51 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         String,
         tokio::sync::broadcast::Receiver<TransactionStatusEvent>,
     )> = Vec::new();
+    let mut last_activity = tokio::time::Instant::now();
+    let mut ping_ticker = tokio::time::interval(PING_INTERVAL);
+    ping_ticker.tick().await; // consume the immediate first tick
 
     loop {
         tokio::select! {
             msg = receiver.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
+                        last_activity = tokio::time::Instant::now();
                         match serde_json::from_str::<SubscribeMessage>(&text) {
                             Ok(sub_msg) => {
                                 if sub_msg.action == "subscribe" {
-                                    info!("Client subscribed to tx_id: {}", sub_msg.tx_id);
-                                    subscriptions.push(sub_msg.tx_id.clone());
-                                    state.add_subscriber(sub_msg.tx_id.clone());
-                                    let rx = state.tx_status_tx.subscribe();
-                                    rx_handles.push((sub_msg.tx_id.clone(), rx));
+                                    if subscriptions.len() >= MAX_SUBSCRIPTIONS_PER_CONNECTION {
+                                        warn!(
+                                            "Client hit subscription limit of {}",
+                                            MAX_SUBSCRIPTIONS_PER_CONNECTION
+                                        );
+                                        let response = json!({
+                                            "msg_type": "error",
+                                            "data": {"message": "subscription limit reached"},
+                                        });
+                                        if let Err(e) = sender.send(Message::Text(response.to_string())).await {
+                                            error!("Failed to send error: {}", e);
+                                            break;
+                                        }
+                                    } else {
+                                        info!("Client subscribed to tx_id: {}", sub_msg.tx_id);
+                                        subscriptions.push(sub_msg.tx_id.clone());
+                                        state.add_subscriber(sub_msg.tx_id.clone());
+                                        let rx = state.tx_status_tx.subscribe();
+                                        rx_handles.push((sub_msg.tx_id.clone(), rx));
 
-                                    let response = json!({
-                                        "msg_type": "subscribed",
-                                        "data": {
-                                            "tx_id": sub_msg.tx_id,
-                                            "status": "subscribed",
-                                        },
-                                    });
+                                        let response = json!({
+                                            "msg_type": "subscribed",
+                                            "data": {
+                                                "tx_id": sub_msg.tx_id,
+                                                "status": "subscribed",
+                                            },
+                                        });
 
-                                    if let Err(e) = sender.send(Message::Text(response.to_string())).await {
-                                        error!("Failed to send subscription confirmation: {}", e);
-                                        break;
+                                        if let Err(e) = sender.send(Message::Text(response.to_string())).await {
+                                            error!("Failed to send subscription confirmation: {}", e);
+                                            break;
+                                        }
                                     }
                                 } else if sub_msg.action == "unsubscribe" {
                                     info!("Client unsubscribed from tx_id: {}", sub_msg.tx_id);
@@ -67,6 +100,9 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                 warn!("Failed to parse WebSocket message: {}", e);
                             }
                         }
+                    }
+                    Some(Ok(Message::Pong(_))) => {
+                        last_activity = tokio::time::Instant::now();
                     }
                     Some(Ok(Message::Close(_))) | None => {
                         info!("WebSocket client disconnected");
@@ -111,6 +147,16 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                     }
                 }
             }
+            _ = ping_ticker.tick() => {
+                if last_activity.elapsed() >= IDLE_TIMEOUT {
+                    info!("WebSocket client timed out due to inactivity");
+                    break;
+                }
+                if let Err(e) = sender.send(Message::Ping(vec![])).await {
+                    error!("Failed to send ping: {}", e);
+                    break;
+                }
+            }
         }
     }
 
@@ -119,6 +165,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     for tx_id in &subscriptions {
         state.remove_subscriber(tx_id);
     }
+    state.release_ws_connection();
 
     info!("WebSocket handler exiting");
 }

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -323,6 +323,9 @@ impl RouterRegistry {
         }
 
         let constraint_str = constraint.unwrap();
+
+        Self::validate_constraint(&constraint_str)?;
+
         if versions.is_empty() {
             return Err(RegistryError::NotFound);
         }
@@ -484,7 +487,6 @@ impl RouterRegistry {
     /// Note: This is a breaking change from the previous Result-based API.
     /// Calling admin() on an uninitialized contract is considered a programming error
     /// rather than a runtime condition, consistent with how similar getters work.
-    pub fn admin(env: Env) -> Address {
     /// # Errors
     /// * [`RegistryError::NotInitialized`] — if the contract has not been initialized.
     pub fn admin(env: Env) -> Result<Address, RegistryError> {
@@ -673,6 +675,33 @@ impl RouterRegistry {
             .instance()
             .get(&DataKey::Versions(name.clone()))
             .unwrap_or(Vec::new(env))
+    }
+
+    /// Validate that a constraint string uses a supported format before use.
+    ///
+    /// Supported formats: `>=X`, `<=X`, `>X`, `<X`, `^X`, `~X`, or an exact
+    /// version number `X`, where `X` is a non-negative integer.
+    ///
+    /// # Errors
+    /// * [`RegistryError::InvalidConstraint`] — if the format is not recognised.
+    fn validate_constraint(constraint: &String) -> Result<(), RegistryError> {
+        let s = constraint.to_string();
+        let num_part = if s.starts_with(">=") || s.starts_with("<=") {
+            &s[2..]
+        } else if s.starts_with('>')
+            || s.starts_with('<')
+            || s.starts_with('^')
+            || s.starts_with('~')
+        {
+            &s[1..]
+        } else {
+            s.as_str()
+        };
+
+        if num_part.is_empty() || num_part.parse::<u32>().is_err() {
+            return Err(RegistryError::InvalidConstraint);
+        }
+        Ok(())
     }
 
     fn version_matches_constraint(


### PR DESCRIPTION
## Summary

Fixes four issues in a single branch:

- **Closes #735** — `api-server/src/handlers.rs`: removed the duplicate `ErrorResponse` import and stripped the extra `Json(ErrorResponse { … })` third element from every error-return tuple in `simulate` and `get_route`, restoring the expected `(StatusCode, Json<ErrorResponse>)` 2-tuple. Also collapsed the three duplicate `Err(e)` match arms in `get_route` into one.

- **Closes #737** — `api-server/src/main.rs`: added the missing closing brace `}` that terminates `build_cors_layer` before `async fn shutdown_signal`, and removed the duplicate `use tracing::info` import (keeping `use tracing::{info, warn}`).

- **Closes #738** — `api-server/src/state.rs` + `api-server/src/websocket.rs`: added an `AtomicUsize` connection counter to `AppState` with `try_acquire_ws_connection` / `release_ws_connection` helpers. The upgrade handler now rejects connections above `MAX_WS_CONNECTIONS` (100). Added a per-connection subscription cap (`MAX_SUBSCRIPTIONS_PER_CONNECTION = 100`) and a ping/pong-based idle timeout (60 s) that closes stale connections.

- **Closes #741** — `contracts/router-registry/src/lib.rs`: added a `validate_constraint` helper that checks constraint syntax before the version-matching loop so callers receive `InvalidConstraint` immediately on malformed input (e.g. `"abc"`, `">>1"`). Also removed the duplicate incomplete `pub fn admin(env: Env) -> Address` declaration left over from a merge conflict, keeping only the `Result<Address, RegistryError>` version.

## Test plan

- [ ] `cargo build -p api-server` compiles without errors
- [ ] `cargo build -p router-registry` compiles without errors
- [ ] Existing unit tests pass: `cargo test -p router-registry`
- [ ] WebSocket connection limit can be verified manually: open 101 concurrent WS connections and confirm the 101st receives `{"error":"connection limit reached"}`
