### PR TITLE
fix/feat: resolve duplicate match arms, duplicate CI jobs, add execution/quote scraping docs, and auth warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,37 +64,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build WASM contracts
-        run: cargo build --target wasm32-unknown-unknown --release
-
-      - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wasm-contracts
-          path: target/wasm32-unknown-unknown/release/*.wasm
-          retention-days: 7
-
-  storage-profiling:
-    name: Storage Profiling
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Profile storage usage
@@ -141,8 +110,12 @@ jobs:
       - name: Build WASM contracts
         run: cargo build --target wasm32-unknown-unknown --release
 
-      - name: Validate dependency graph
-        run: bash scripts/validate-dependencies.sh
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-contracts
+          path: target/wasm32-unknown-unknown/release/*.wasm
+          retention-days: 7
 
   integration-test:
     name: Integration Tests (Testnet)
@@ -231,10 +204,10 @@ jobs:
           echo "Current coverage: ${COVERAGE_PERCENT}%"
 
           if (( $(echo "$COVERAGE < 0.70" | bc -l) )); then
-            echo "❌ Coverage ${COVERAGE_PERCENT}% is below the 70% threshold"
+            echo "Coverage ${COVERAGE_PERCENT}% is below the 70% threshold"
             exit 1
           else
-            echo "✅ Coverage ${COVERAGE_PERCENT}% meets the 70% threshold"
+            echo "Coverage ${COVERAGE_PERCENT}% meets the 70% threshold"
           fi
 
       - name: Upload coverage report

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -12,7 +12,6 @@ use crate::{
     types::{
         ErrorCode, ErrorResponse, FeeEstimate, SimulateRequest, SimulateResponse, SimulationDetail,
     },
-    types::{ErrorResponse, FeeEstimate, SimulateRequest, SimulateResponse, SimulationDetail},
 };
 
 /// GET /health
@@ -42,9 +41,6 @@ pub async fn simulate(
                 "target and function are required",
                 "target",
             )),
-            Json(ErrorResponse {
-                error: "target and function are required".to_string(),
-            }),
         ));
     }
 
@@ -56,10 +52,6 @@ pub async fn simulate(
                 "target must be a 56-character Stellar contract ID starting with C",
                 "target",
             )),
-            Json(ErrorResponse {
-                error: "target must be a 56-character Stellar contract ID starting with C"
-                    .to_string(),
-            }),
         ));
     }
 
@@ -73,9 +65,6 @@ pub async fn simulate(
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(ErrorCode::RpcError, e.to_string())),
-                Json(ErrorResponse {
-                    error: e.to_string(),
-                }),
             )
         })?;
 
@@ -122,23 +111,7 @@ pub async fn get_route(
         )),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new(
-                ErrorCode::NotFound,
-                format!("route '{}' not found", name),
-            )),
-        )),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::new(ErrorCode::RpcError, e.to_string())),
-            Json(ErrorResponse {
-                error: format!("route '{}' not found", name),
-            }),
-        )),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
         )),
     }
 }

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -21,6 +21,11 @@ Soroban smart contracts run inside the Stellar network as WASM and cannot open s
 | `router_middleware_circuit_open` | Gauge | `contract`, `route` | 1 if the circuit breaker is open |
 | `router_middleware_failure_count` | Gauge | `contract`, `route` | Consecutive failure count |
 | `router_registry_total_names` | Gauge | `contract` | Total contract names registered |
+| `router_quote_total_generated` | Gauge | `contract` | Running total of `quote_generated` events |
+| `router_quote_total_fee_estimated` | Gauge | `contract` | Running total of `fee_estimated` events |
+| `router_execution_total_executions` | Gauge | `contract` | Cumulative executions from on-chain storage |
+| `router_execution_total_errors` | Gauge | `contract` | Cumulative execution errors from on-chain storage |
+| `router_execution_max_retries` | Gauge | `contract` | Configured max retries from on-chain storage |
 | `router_scrape_duration_seconds` | Histogram | `contract` | Time spent scraping each contract |
 | `router_scrape_errors_total` | Counter | `contract` | Number of failed scrape attempts |
 | `router_up` | Gauge | — | 1 if the last scrape cycle succeeded |
@@ -85,6 +90,16 @@ Options:
       [env: ROUTER_REGISTRY_CONTRACT_ID]
       [default: ]
 
+  --quote-contract-id <CONTRACT_ID>
+      Contract ID of the deployed router-quote contract
+      [env: ROUTER_QUOTE_CONTRACT_ID]
+      [default: ]
+
+  --execution-contract-id <CONTRACT_ID>
+      Contract ID of the deployed router-execution contract
+      [env: ROUTER_EXECUTION_CONTRACT_ID]
+      [default: ]
+
   --scrape-interval-secs <SECONDS>
       How often (in seconds) to poll the Soroban RPC for fresh data
       [env: ROUTER_SCRAPE_INTERVAL_SECS]
@@ -114,6 +129,8 @@ export ROUTER_RPC_URL="https://soroban-testnet.stellar.org"
 export ROUTER_CORE_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
 export ROUTER_MIDDLEWARE_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
 export ROUTER_REGISTRY_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
+export ROUTER_QUOTE_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
+export ROUTER_EXECUTION_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
 export ROUTER_SCRAPE_INTERVAL_SECS=30
 export ROUTER_LISTEN="0.0.0.0:9090"
 
@@ -127,10 +144,57 @@ export ROUTER_RPC_URL="https://soroban-mainnet.stellar.org"
 export ROUTER_NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export ROUTER_CORE_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
 export ROUTER_MIDDLEWARE_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
+export ROUTER_QUOTE_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
+export ROUTER_EXECUTION_CONTRACT_ID="CBGTG...YOUR_CONTRACT_ID"
 export ROUTER_SCRAPE_INTERVAL_SECS=60
 
 ./target/release/router-metrics-exporter
 ```
+
+## Authentication
+
+The `/metrics` endpoint can be protected with API key authentication.
+
+> **Warning:** Authentication is **disabled by default**. An unauthenticated
+> `/metrics` endpoint exposes contract state, circuit breaker status, route
+> names, and error rates to any client. Always enable authentication in
+> production deployments.
+
+### Enabling authentication
+
+Set the following environment variables before starting the exporter:
+
+```bash
+export ROUTER_AUTH_ENABLED=true
+export ROUTER_API_KEY="your-secret-api-key"
+```
+
+When `ROUTER_AUTH_ENABLED` is not set (or set to `false`), the exporter logs
+a startup warning:
+
+```
+WARN router_metrics_exporter::auth: Metrics endpoint is unauthenticated — set ROUTER_AUTH_ENABLED=true for production
+```
+
+### Making authenticated requests
+
+The exporter accepts the API key in either of two request headers:
+
+```bash
+# Authorization: Bearer header
+curl -H "Authorization: Bearer your-secret-api-key" http://localhost:9090/metrics
+
+# X-API-Key header
+curl -H "X-API-Key: your-secret-api-key" http://localhost:9090/metrics
+```
+
+### Deployment recommendations
+
+- Place the exporter behind a reverse proxy (nginx, Caddy, Traefik) that enforces
+  TLS and restricts access to your Prometheus scraper IP.
+- Use a network firewall or Kubernetes NetworkPolicy to allow only the Prometheus
+  pod to reach port 9090.
+- Rotate `ROUTER_API_KEY` regularly and update the Prometheus scrape config accordingly.
 
 ## Prometheus Configuration
 
@@ -140,6 +204,9 @@ Add the exporter as a scrape target in your `prometheus.yml`:
 scrape_configs:
   - job_name: 'stellar-router'
     scrape_interval: 30s
+    # Include the API key if ROUTER_AUTH_ENABLED=true
+    authorization:
+      credentials: 'your-secret-api-key'
     static_configs:
       - targets: ['localhost:9090']
         labels:
@@ -155,6 +222,19 @@ Example queries for a Grafana dashboard:
 
 ```promql
 rate(router_core_total_routed{contract="CBGTG..."}[5m]) * 60
+```
+
+### Execution error rate
+
+```promql
+rate(router_execution_total_errors{contract="CBGTG..."}[5m])
+  / rate(router_execution_total_executions{contract="CBGTG..."}[5m])
+```
+
+### Quote activity
+
+```promql
+rate(router_quote_total_generated{contract="CBGTG..."}[5m]) * 60
 ```
 
 ### Circuit breaker status
@@ -190,6 +270,8 @@ The exporter calls view functions on each contract via `simulateTransaction`:
 - **router-core**: `total_routed()`, `get_all_routes()`, `get_route(name)` for each route
 - **router-middleware**: `total_calls()`, `get_configured_routes()`, `circuit_breaker_state(route)` for each route
 - **router-registry**: `get_all_names()` (total count)
+- **router-quote**: `quote_generated` and `fee_estimated` events via `getEvents` RPC
+- **router-execution**: `TotalExecutions`, `TotalErrors`, `MaxRetries` from on-chain storage via `getLedgerEntries`
 
 Each contract scrape is timed and any error increments the `router_scrape_errors_total` counter.
 
@@ -278,6 +360,8 @@ cargo test -p router-metrics-exporter
 ```bash
 cargo run -p router-metrics-exporter -- \
   --core-contract-id "CBGTG..." \
+  --execution-contract-id "CBGTG..." \
+  --quote-contract-id "CBGTG..." \
   --scrape-interval-secs 10
 ```
 

--- a/metrics/src/auth.rs
+++ b/metrics/src/auth.rs
@@ -39,6 +39,10 @@ impl AuthConfig {
             warn!("Authentication enabled but ROUTER_API_KEY not set. Authentication will be disabled.");
         }
 
+        if !enabled {
+            warn!("Metrics endpoint is unauthenticated — set ROUTER_AUTH_ENABLED=true for production");
+        }
+
         AuthConfig {
             enabled: enabled && api_key.is_some(),
             api_key,


### PR DESCRIPTION
## Summary

This PR resolves four issues across the `api-server`, CI workflow, and `metrics` crate in a single branch.

---

### Closes #734 — `get_route` handler: duplicate `Err(e)` match arms

**File:** `api-server/src/handlers.rs`

The `get_route` handler had three successive `Err(e)` match arms. Only the first was reachable; the other two were dead code. To make it worse, the first reachable arm used `ErrorCode::NotFound` for an RPC error, misclassifying the failure.

**Changes:**
- Remove the duplicate `use crate::types` import that would cause a compilation error
- Collapse the three `Err(e)` arms in `get_route` into a single arm using `StatusCode::INTERNAL_SERVER_ERROR` and `ErrorCode::RpcError` — matching the suggested fix in the issue
- Remove the extra `Json(ErrorResponse { ... })` elements from the triple-element `Err` tuples in `simulate` (the return type is `(StatusCode, Json<ErrorResponse>)`, not a 3-tuple)

---

### Closes #736 — Duplicate `storage-profiling` job names in `ci.yml`

**File:** `.github/workflows/ci.yml`

YAML maps silently drop duplicate keys, so the first `storage-profiling` block (which built WASM and uploaded artifacts) was completely overwritten by the second block (which ran `profile-storage.sh`). The `build` job independently performed the same WASM build, and also duplicated the `Validate dependency graph` step already owned by `dependency-validation`.

**Changes:**
- Remove the first `storage-profiling` block entirely (WASM build + upload); the dedicated `build` job already does this
- Remove the duplicate `Validate dependency graph` step from the `build` job; it belongs exclusively to `dependency-validation`
- The remaining `storage-profiling` job runs `scripts/profile-storage.sh` and uploads `storage-profile.txt` as before

---

### Closes #742 — Add scrape for `router-execution` and `router-quote` contracts

**File:** `metrics/README.md`

The collector and metrics struct already implement `scrape_quote` and `scrape_execution`, and the CLI args `--quote-contract-id` / `--execution-contract-id` exist. The documentation was not updated to reflect any of this.

**Changes:**
- Add `router_quote_total_generated`, `router_quote_total_fee_estimated`, `router_execution_total_executions`, `router_execution_total_errors`, and `router_execution_max_retries` to the metrics table
- Document `--quote-contract-id` (`ROUTER_QUOTE_CONTRACT_ID`) and `--execution-contract-id` (`ROUTER_EXECUTION_CONTRACT_ID`) CLI flags
- Update testnet/mainnet deployment examples to include both new contract IDs
- Update the Architecture > Scraping Strategy section to list `router-quote` (via `getEvents`) and `router-execution` (via `getLedgerEntries`)
- Add execution error rate and quote activity PromQL example queries for Grafana

---

### Closes #752 — Add authentication warning when metrics endpoint is unauthenticated

**Files:** `metrics/src/auth.rs`, `metrics/README.md`

`ROUTER_AUTH_ENABLED` defaulted to `false`, meaning any misconfigured deployment silently exposed contract state, circuit breaker status, and error rates without any log-level indication.

**Changes (`auth.rs`):**
- Add `warn!("Metrics endpoint is unauthenticated — set ROUTER_AUTH_ENABLED=true for production")` in `AuthConfig::from_env()` whenever auth is disabled — operators will see this at startup in logs

**Changes (`README.md`):**
- Add a dedicated **Authentication** section documenting `ROUTER_AUTH_ENABLED` and `ROUTER_API_KEY`
- Show the exact startup warning text so operators know what to watch for
- Document `Authorization: Bearer` and `X-API-Key` request header formats
- Add deployment recommendations: reverse proxy with TLS, Kubernetes NetworkPolicy, key rotation
- Update the Prometheus scrape config example to include the `authorization` stanza

---

## Files changed

| File | Issues |
|------|--------|
| `api-server/src/handlers.rs` | #734 |
| `.github/workflows/ci.yml` | #736 |
| `metrics/src/auth.rs` | #752 |
| `metrics/README.md` | #742, #752 |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)