### PR TITLE
fix/feat: alias_resolved event, nonce cache eviction, event constant consistency, upgrade docs

### DIFF
--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -82,6 +82,9 @@ pub const EVENT_ALIAS_ADDED: &str = "alias_added";
 /// Standard event topic for alias removals
 pub const EVENT_ALIAS_REMOVED: &str = "alias_removed";
 
+/// Standard event topic for alias resolution (emitted when resolve goes through an alias)
+pub const EVENT_ALIAS_RESOLVED: &str = "alias_resolved";
+
 /// Standard event topic for route removals
 pub const EVENT_ROUTE_REMOVED: &str = "route_removed";
 

--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -726,15 +726,22 @@ impl RouterCore {
         }
 
         // Resolve alias if present
-        let resolved_name = if let Some(original) = env
+        let (resolved_name, alias_used) = if let Some(original) = env
             .storage()
             .instance()
             .get::<DataKey, String>(&DataKey::Alias(name.clone()))
         {
-            original
+            (original, true)
         } else {
-            name.clone()
+            (name.clone(), false)
         };
+
+        if alias_used {
+            env.events().publish(
+                (Symbol::new(&env, router_common::EVENT_ALIAS_RESOLVED),),
+                (name.clone(), resolved_name.clone()),
+            );
+        }
 
         // Score-based selection: the best non-paused scored route is maintained
         // in a cached storage key (DataKey::BestRoute), updated whenever scores,
@@ -2255,7 +2262,7 @@ mod tests {
             event.1,
             vec![
                 &env,
-                Symbol::new(&env, "route_resolve_paused").into_val(&env)
+                Symbol::new(&env, router_common::EVENT_ROUTE_RESOLVE_PAUSED).into_val(&env)
             ]
         );
         let (emitted_name,): (String,) = event.2.into_val(&env);
@@ -2913,7 +2920,7 @@ mod tests {
             event.1,
             vec![
                 &env,
-                Symbol::new(&env, "route_resolve_paused").into_val(&env)
+                Symbol::new(&env, router_common::EVENT_ROUTE_RESOLVE_PAUSED).into_val(&env)
             ]
         );
         let (emitted_name,): (String,) = event.2.into_val(&env);

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -172,14 +172,167 @@ If you need to change a storage type, use a two-phase upgrade:
 
 ---
 
+## Zero-Downtime Upgrade Path
+
+In-place WASM replacement (described above) is the preferred path because it
+preserves all storage and requires no state migration. Use it whenever your
+changes are backward-compatible (new functions, new `DataKey` variants, bug
+fixes that do not change stored types).
+
+When a breaking storage change is unavoidable, you must deploy a **new contract
+instance** and migrate state. This is more disruptive but can still be done with
+minimal downtime:
+
+### Phase A — Deploy and populate the new contract
+
+1. Deploy a fresh contract instance with the new WASM:
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/router_core.wasm \
+  --network mainnet \
+  --source admin
+```
+
+Save the new `<NEW_CONTRACT_ID>`.
+
+2. Initialize it:
+
+```bash
+stellar contract invoke --id <NEW_CONTRACT_ID> --network mainnet --source admin \
+  -- initialize --admin <ADMIN_ADDRESS>
+```
+
+3. Run your off-chain migration script to copy all routes, aliases, scores, and
+   metadata from the old contract to the new one. Keep the old contract alive
+   and accepting reads during this window.
+
+Example migration script using the Stellar CLI:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+OLD_ID="<OLD_CONTRACT_ID>"
+NEW_ID="<NEW_CONTRACT_ID>"
+NETWORK="mainnet"
+SOURCE="admin"
+
+# Fetch all route names from the old contract
+NAMES=$(stellar contract invoke --id "$OLD_ID" --network "$NETWORK" --source "$SOURCE" \
+  -- get_route_names 2>/dev/null | jq -r '.[]')
+
+for name in $NAMES; do
+  # Read route entry
+  ADDR=$(stellar contract invoke --id "$OLD_ID" --network "$NETWORK" --source "$SOURCE" \
+    -- resolve --name "$name" 2>/dev/null)
+
+  # Register on new contract
+  stellar contract invoke --id "$NEW_ID" --network "$NETWORK" --source "$SOURCE" \
+    -- register --caller "$ADMIN_ADDRESS" --name "$name" --address "$ADDR"
+
+  echo "Migrated route: $name -> $ADDR"
+done
+
+# Fetch and migrate aliases
+ALIASES=$(stellar contract invoke --id "$OLD_ID" --network "$NETWORK" --source "$SOURCE" \
+  -- get_aliases 2>/dev/null | jq -r '.[]')
+
+for alias in $ALIASES; do
+  TARGET=$(stellar contract invoke --id "$OLD_ID" --network "$NETWORK" --source "$SOURCE" \
+    -- get_alias --alias_name "$alias" 2>/dev/null)
+
+  stellar contract invoke --id "$NEW_ID" --network "$NETWORK" --source "$SOURCE" \
+    -- add_alias --caller "$ADMIN_ADDRESS" --existing_name "$TARGET" --alias_name "$alias"
+
+  echo "Migrated alias: $alias -> $TARGET"
+done
+
+echo "Migration complete."
+```
+
+### Phase B — Atomic cutover
+
+Once the new contract is fully populated:
+
+1. Point your off-chain registry and any router-registry entries to
+   `<NEW_CONTRACT_ID>`.
+2. Pause the old contract to prevent stale writes:
+
+```bash
+stellar contract invoke --id <OLD_CONTRACT_ID> --network mainnet --source admin \
+  -- set_paused --caller <ADMIN_ADDRESS> --paused true
+```
+
+3. Verify the new contract is serving traffic correctly (see verification steps
+   below).
+
+### Phase C — Decommission the old contract
+
+After a monitoring window (at least 24 hours), you may stop routing traffic to
+the old contract. Because Soroban contracts cannot be deleted, simply cease
+calling it. Update all documentation and tooling to reference `<NEW_CONTRACT_ID>`
+only.
+
+---
+
+## Pre/Post-Upgrade Verification
+
+### Before upgrading
+
+Confirm the current state is readable and the contract responds correctly:
+
+```bash
+# Verify admin is set
+stellar contract invoke --id <CONTRACT_ID> --network mainnet --source admin \
+  -- admin
+
+# Verify route count is non-zero
+stellar contract invoke --id <CONTRACT_ID> --network mainnet --source admin \
+  -- get_route_count
+
+# Spot-check a known route
+stellar contract invoke --id <CONTRACT_ID> --network mainnet --source admin \
+  -- resolve --name <KNOWN_ROUTE_NAME>
+```
+
+### After upgrading
+
+Run the same checks immediately after the upgrade executes:
+
+```bash
+# Same three checks above — if any fail, initiate rollback immediately
+
+# Additionally verify the new WASM hash matches what was uploaded
+stellar contract info --id <CONTRACT_ID> --network mainnet | grep wasm_hash
+```
+
+---
+
 ## Rollback
 
 Soroban does not support automatic rollback of a WASM upgrade. If an upgrade
 introduces a bug:
 
 1. Build the previous WASM version.
-2. Upload it to the network (step 3 above).
-3. Call `upgrade()` with the old WASM hash.
+2. Upload it to the network:
+
+```bash
+stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/router_core_previous.wasm \
+  --network mainnet \
+  --source admin
+```
+
+3. Call `upgrade()` with the old WASM hash:
+
+```bash
+stellar contract invoke --id <CONTRACT_ID> --network mainnet --source admin \
+  -- upgrade --caller <ADMIN_ADDRESS> --new_wasm_hash <PREVIOUS_WASM_HASH>
+```
+
+**Always upload the rollback WASM before the upgrade executes** (step 3 of the
+upgrade strategy) so the hash is available immediately if something goes wrong.
 
 This is why all upgrades should be queued through router-timelock — the delay
 window gives time to test the new WASM on testnet and cancel the upgrade if
@@ -189,6 +342,8 @@ issues are found before it executes on mainnet.
 
 ## Upgrade Checklist
 
+### General (all contracts)
+
 Before upgrading any contract on mainnet:
 
 - [ ] New WASM tested on testnet with production-like data
@@ -197,7 +352,71 @@ Before upgrading any contract on mainnet:
 - [ ] Upgrade queued via router-timelock with at least 24h delay
 - [ ] Migration function (if needed) tested on testnet
 - [ ] Rollback WASM uploaded and hash noted
+- [ ] Pre-upgrade verification commands pass (see Pre/Post-Upgrade Verification)
 - [ ] On-chain monitoring active during upgrade window
+- [ ] Post-upgrade verification commands pass; rollback initiated immediately if any fail
+
+### router-core
+
+- [ ] Confirmed no changes to `RouteEntry` field types (XDR incompatibility)
+- [ ] Confirmed `DataKey` variants not reordered
+- [ ] All aliases resolve correctly after upgrade
+- [ ] Scored routes return the expected best-route after upgrade
+
+### router-registry
+
+- [ ] `ContractEntry` fields unchanged or two-phase migration prepared
+- [ ] Version lists (`DataKey::Versions`) remain `Vec<u32>`
+
+### router-access
+
+- [ ] Role hierarchy entries still readable (check `DataKey::RoleParent`)
+- [ ] `DataKey::HasRole` type unchanged
+
+### router-middleware
+
+- [ ] `RouteConfig` struct fields not removed or reordered
+- [ ] Circuit breaker state (`DataKey::CircuitState`) readable after upgrade
+
+### router-timelock
+
+- [ ] `TimelockOp.is_critical` field still present
+- [ ] No pending timelock operations that would be invalidated by the schema change
+- [ ] Cancel any in-flight operations before a schema-breaking upgrade
+
+### router-multicall
+
+- [ ] `CallDescriptor` changes are safe (it is not persisted, so field additions are safe)
+
+---
+
+## Registry Version Coordination
+
+`router-registry` tracks deployed contract versions in `DataKey::Versions`
+(a `Vec<u32>`). When you deploy a new WASM version via in-place upgrade, register
+the new version in the registry immediately after the upgrade executes:
+
+```bash
+stellar contract invoke --id <REGISTRY_ID> --network mainnet --source admin \
+  -- register_version \
+  --caller <ADMIN_ADDRESS> \
+  --contract_id <CORE_CONTRACT_ID> \
+  --version <NEW_VERSION_NUMBER>
+```
+
+When you deploy a completely new contract instance (state-migration path), register
+it as a new entry rather than a new version of the old contract:
+
+```bash
+stellar contract invoke --id <REGISTRY_ID> --network mainnet --source admin \
+  -- register \
+  --caller <ADMIN_ADDRESS> \
+  --name "router-core-v2" \
+  --address <NEW_CONTRACT_ID>
+```
+
+Keep both the old and new entries in the registry until the old contract is fully
+decommissioned, so tooling and dashboards can reference either address by name.
 
 ---
 

--- a/metrics/src/replay_protection.rs
+++ b/metrics/src/replay_protection.rs
@@ -91,13 +91,10 @@ impl NonceCache {
             return false;
         }
 
-        // Check cache size limit
+        // If still at capacity after TTL cleanup, evict the oldest entry to
+        // bound memory use rather than rejecting a legitimate nonce.
         if self.cache.len() >= self.config.cache_size {
-            warn!(
-                "Nonce cache at capacity ({}), rejecting new nonce",
-                self.config.cache_size
-            );
-            return false;
+            self.evict_oldest();
         }
 
         // Add nonce to cache
@@ -113,6 +110,18 @@ impl NonceCache {
     fn cleanup_expired(&self, now: u64) {
         let ttl = self.config.nonce_ttl_secs;
         self.cache.retain(|_, entry| now - entry.timestamp < ttl);
+    }
+
+    /// Evict the single oldest nonce to make room for a new entry.
+    fn evict_oldest(&self) {
+        if let Some(oldest_key) = self
+            .cache
+            .iter()
+            .min_by_key(|entry| entry.value().timestamp)
+            .map(|entry| entry.key().clone())
+        {
+            self.cache.remove(&oldest_key);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses four open issues across router-core, metrics, and docs.

---

### Closes #740 — Emit `alias_resolved` event on alias resolution

**Problem:** When `resolve` is called with an alias name, the alias was silently resolved with no observable event. Off-chain monitoring could not distinguish alias-based resolutions from direct ones, making alias usage tracking and deprecation planning impossible.

**Fix:** Added `EVENT_ALIAS_RESOLVED = "alias_resolved"` constant to `router-common` and updated the `resolve` function in `router-core` to emit `(alias_resolved,)` with payload `(alias_name, resolved_name)` whenever resolution goes through an alias. The existing `routed` event is still emitted for the final outcome.

**Files changed:**
- `contracts/router-common/src/lib.rs` — new `EVENT_ALIAS_RESOLVED` constant
- `contracts/router-core/src/lib.rs` — emit event when `DataKey::Alias` lookup succeeds

---

### Closes #744 — Bound `NonceCache` memory by evicting oldest entry at capacity

**Problem:** After TTL-based cleanup, if the cache remained at capacity (all cached nonces still within TTL), new nonces were rejected with a warning. This caused valid requests to fail under sustained load, which is worse than a small replay window.

**Fix:** Replaced the "reject when full" path with an `evict_oldest()` helper that removes the single entry with the lowest timestamp, then inserts the new nonce. The cache stays bounded at `cache_size` entries and valid nonces are never refused solely due to cache pressure.

**Files changed:**
- `metrics/src/replay_protection.rs` — `evict_oldest()` helper; `check_and_add` calls it instead of returning `false`

---

### Closes #747 — Replace remaining inline `"route_resolve_paused"` literals with constant

**Problem:** Two test assertions still used the raw string literal `"route_resolve_paused"` instead of `router_common::EVENT_ROUTE_RESOLVE_PAUSED`, creating a consistency gap. If the event name changed in `router-common`, the assertions would silently diverge.

**Fix:** Replaced both occurrences in the test section of `router-core/src/lib.rs` with `router_common::EVENT_ROUTE_RESOLVE_PAUSED`.

**Files changed:**
- `contracts/router-core/src/lib.rs` — two test assertions updated

---

### Closes #751 — Expand `docs/upgrading.md` with zero-downtime path, CLI verification, rollback detail, registry coordination, and per-contract checklists

**Problem:** The upgrade guide covered in-place WASM replacement but left several operator-facing gaps: no zero-downtime path for breaking schema changes, no CLI verification commands, sparse rollback instructions, no registry coordination guidance, and no per-contract checklists.

**What was added:**
- **Zero-downtime upgrade path** — three-phase flow (deploy new contract, off-chain migration, atomic cutover) with a worked shell script that migrates routes and aliases via the Stellar CLI
- **Pre/Post-upgrade verification** — exact `stellar contract invoke` commands to confirm contract health before and after each upgrade, with explicit rollback trigger
- **Rollback** — expanded with full CLI commands to upload the previous WASM and call `upgrade()` with the old hash
- **Registry version coordination** — how to register a new WASM version vs. a new contract instance in `router-registry`
- **Per-contract upgrade checklists** — individual checklists for router-core, router-registry, router-access, router-middleware, router-timelock, and router-multicall

**Files changed:**
- `docs/upgrading.md` — ~220 lines added across new sections and expanded checklist

---

## Test plan

- [ ] Build `router-core` and `router-common` with `cargo build --target wasm32-unknown-unknown --release` — confirm no compile errors
- [ ] Run `cargo test` in `contracts/router-core` — existing tests still pass with constant-based assertions
- [ ] Build `metrics` crate — confirm `evict_oldest` compiles and `check_and_add` no longer returns `false` on capacity
- [ ] Review `docs/upgrading.md` for accuracy of CLI examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)