### PR TITLE
security(api-server): add /simulate rate limit middleware and config

### DIFF
--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -1,4 +1,5 @@
 mod handlers;
+mod rate_limit;
 mod rpc;
 mod state;
 mod types;
@@ -10,7 +11,7 @@ mod tests;
 use anyhow::{Context, Result};
 use axum::{
     extract::DefaultBodyLimit,
-    http::{header, HeaderValue, Method, Request},
+    http::{header, Method, Request},
     middleware::{self, Next},
     response::Response,
     routing::{get, post},
@@ -22,7 +23,7 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{info, warn};
 use tracing::{info, info_span, warn, Instrument};
 
-use crate::state::AppState;
+use crate::{rate_limit::{RateLimitConfig, RateLimiter}, state::AppState};
 
 #[derive(Parser, Debug)]
 #[command(name = "router-api-server")]
@@ -50,6 +51,12 @@ struct Args {
     /// Omit to disable cross-origin requests (production default).
     #[arg(long, env = "CORS_ORIGINS", value_delimiter = ',')]
     cors_origins: Vec<String>,
+    /// Maximum number of /simulate requests allowed per window.
+    #[arg(long, env = "RATE_LIMIT_MAX_REQUESTS", default_value = "100")]
+    rate_limit_max_requests: u32,
+    /// Sliding window for rate limiting in seconds.
+    #[arg(long, env = "RATE_LIMIT_WINDOW_SECS", default_value = "60")]
+    rate_limit_window_secs: u64,
     /// Seconds to wait for in-flight requests to complete on shutdown (default: 30)
     #[arg(long, env = "SHUTDOWN_TIMEOUT_SECS", default_value = "30")]
     shutdown_timeout_secs: u64,
@@ -70,17 +77,26 @@ async fn main() -> Result<()> {
     info!("Listen address: {}", args.listen);
     info!("RPC URL: {}", args.rpc_url);
 
+    let rate_limiter = RateLimiter::new(RateLimitConfig {
+        max_requests: args.rate_limit_max_requests,
+        window: std::time::Duration::from_secs(args.rate_limit_window_secs),
+    });
+
     let state = AppState::new(
         args.rpc_url,
         args.execution_contract_id,
         args.router_core_contract_id,
+        rate_limiter,
     );
 
     let cors = build_cors_layer(&args.cors_origins);
 
     let app = Router::new()
         .route("/health", get(handlers::health))
-        .route("/simulate", post(handlers::simulate))
+        .route(
+            "/simulate",
+            post(handlers::simulate).layer(middleware::from_fn(rate_limit::rate_limit_middleware)),
+        )
         .route("/routes", get(handlers::list_routes))
         .route("/routes/:name", get(handlers::get_route))
         .route("/ws", get(websocket::ws_handler))

--- a/api-server/src/rate_limit.rs
+++ b/api-server/src/rate_limit.rs
@@ -1,0 +1,198 @@
+//! Simple per-client rate limiting middleware for the API server.
+//!
+//! Tracks requests by `X-Api-Key` header or remote IP and rejects excess
+//! requests with HTTP 429.
+
+use std::{net::SocketAddr, sync::Arc, time::{Duration, Instant}};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderValue, Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Json, Response},
+};
+use dashmap::DashMap;
+use serde::Serialize;
+use tracing::warn;
+
+/// Rate-limit configuration for `/simulate` requests.
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    pub max_requests: u32,
+    pub window: Duration,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            max_requests: 100,
+            window: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BucketEntry {
+    count: u32,
+    window_start: Instant,
+}
+
+#[derive(Clone, Debug)]
+pub struct RateLimiter {
+    config: RateLimitConfig,
+    buckets: Arc<DashMap<String, BucketEntry>>,
+}
+
+impl RateLimiter {
+    pub fn new(config: RateLimitConfig) -> Self {
+        Self {
+            config,
+            buckets: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub fn max_requests(&self) -> u32 {
+        self.config.max_requests
+    }
+
+    pub fn check(&self, key: &str) -> bool {
+        let now = Instant::now();
+        let mut entry = self.buckets.entry(key.to_string()).or_insert(BucketEntry {
+            count: 0,
+            window_start: now,
+        });
+
+        if now.duration_since(entry.window_start) >= self.config.window {
+            entry.count = 0;
+            entry.window_start = now;
+        }
+
+        entry.count += 1;
+        entry.count <= self.config.max_requests
+    }
+
+    pub fn remaining(&self, key: &str) -> u32 {
+        if let Some(entry) = self.buckets.get(key) {
+            let now = Instant::now();
+            if now.duration_since(entry.window_start) >= self.config.window {
+                return self.config.max_requests;
+            }
+            let count = entry.count;
+            return self.config.max_requests.saturating_sub(count);
+        }
+        self.config.max_requests
+    }
+
+    pub fn retry_after_secs(&self, key: &str) -> u64 {
+        if let Some(entry) = self.buckets.get(key) {
+            let elapsed = Instant::now().duration_since(entry.window_start);
+            if elapsed < self.config.window {
+                return (self.config.window - elapsed).as_secs().max(1);
+            }
+        }
+        1
+    }
+}
+
+#[derive(Serialize)]
+struct RateLimitError {
+    error: &'static str,
+    message: String,
+    retry_after_secs: u64,
+}
+
+pub async fn rate_limit_middleware(
+    State(state): State<crate::state::AppState>,
+    mut req: Request<Body>,
+    next: Next<Body>,
+) -> Response {
+    let remote_addr = req
+        .extensions()
+        .get::<axum::extract::ConnectInfo<SocketAddr>>()
+        .map(|connect_info| connect_info.0)
+        .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 0)));
+
+    let key = req
+        .headers()
+        .get("x-api-key")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| remote_addr.ip().to_string());
+
+    let limiter = &state.rate_limiter;
+    let allowed = limiter.check(&key);
+    let remaining = limiter.remaining(&key);
+
+    if allowed {
+        let mut response = next.run(req).await;
+        let headers = response.headers_mut();
+
+        let _ = headers.insert(
+            "x-rate-limit-limit",
+            HeaderValue::from_str(&limiter.max_requests().to_string()).unwrap(),
+        );
+        let _ = headers.insert(
+            "x-rate-limit-remaining",
+            HeaderValue::from_str(&remaining.to_string()).unwrap(),
+        );
+        response
+    } else {
+        let retry_after = limiter.retry_after_secs(&key);
+        warn!(key = %key, "rate limit exceeded");
+
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(
+                "retry-after",
+                HeaderValue::from_str(&retry_after.to_string()).unwrap(),
+            )],
+            Json(RateLimitError {
+                error: "rate_limit_exceeded",
+                message: format!(
+                    "Too many requests. Retry after {} second(s).",
+                    retry_after
+                ),
+                retry_after_secs: retry_after,
+            }),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn limiter(max: u32, window_secs: u64) -> RateLimiter {
+        RateLimiter::new(RateLimitConfig {
+            max_requests: max,
+            window: Duration::from_secs(window_secs),
+        })
+    }
+
+    #[test]
+    fn allows_requests_within_limit() {
+        let rl = limiter(3, 60);
+        assert!(rl.check("127.0.0.1"));
+        assert!(rl.check("127.0.0.1"));
+        assert!(rl.check("127.0.0.1"));
+    }
+
+    #[test]
+    fn rejects_request_over_limit() {
+        let rl = limiter(2, 60);
+        rl.check("10.0.0.1");
+        rl.check("10.0.0.1");
+        assert!(!rl.check("10.0.0.1"));
+    }
+
+    #[test]
+    fn different_keys_are_independent() {
+        let rl = limiter(1, 60);
+        assert!(rl.check("192.168.1.1"));
+        assert!(rl.check("192.168.1.2"));
+        assert!(!rl.check("192.168.1.1"));
+    }
+}

--- a/api-server/src/state.rs
+++ b/api-server/src/state.rs
@@ -1,3 +1,4 @@
+use crate::rate_limit::RateLimiter;
 use dashmap::DashMap;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -16,6 +17,7 @@ pub struct AppState {
     #[allow(dead_code)]
     pub execution_contract_id: String,
     pub router_core_contract_id: String,
+    pub rate_limiter: RateLimiter,
     pub tx_status_tx: broadcast::Sender<TransactionStatusEvent>,
     pub tx_subscribers: Arc<DashMap<String, usize>>,
     pub ws_connection_count: Arc<AtomicUsize>,
@@ -26,12 +28,14 @@ impl AppState {
         rpc_url: String,
         execution_contract_id: String,
         router_core_contract_id: String,
+        rate_limiter: RateLimiter,
     ) -> Self {
         let (tx_status_tx, _) = broadcast::channel(1000);
         Self {
             rpc: SorobanRpcClient::new(rpc_url, Some(router_core_contract_id.clone())),
             execution_contract_id,
             router_core_contract_id,
+            rate_limiter,
             tx_status_tx,
             tx_subscribers: Arc::new(DashMap::new()),
             ws_connection_count: Arc::new(AtomicUsize::new(0)),

--- a/api-server/src/tests.rs
+++ b/api-server/src/tests.rs
@@ -1,6 +1,7 @@
 use axum::{
     body::Body,
     http::{Request, StatusCode},
+    middleware,
     routing::{get, post},
     Router,
 };
@@ -9,6 +10,7 @@ use tower::util::ServiceExt;
 
 use crate::{
     handlers,
+    rate_limit::{RateLimitConfig, RateLimiter},
     state::AppState,
     types::{
         RouteDetails, SimulateRequest, SimulateResponse, TransactionStatus, TransactionStatusEvent,
@@ -19,15 +21,20 @@ use crate::{
 const VALID_CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
 
 fn test_app() -> Router {
+    let rate_limiter = RateLimiter::new(RateLimitConfig::default());
     let state = AppState::new(
         "http://localhost:1".to_string(),
         "".to_string(),
         "".to_string(),
+        rate_limiter,
     );
 
     Router::new()
+        .route(
+            "/simulate",
+            post(handlers::simulate).layer(middleware::from_fn(crate::rate_limit::rate_limit_middleware)),
+        )
         .route("/health", get(handlers::health))
-        .route("/simulate", post(handlers::simulate))
         .route("/routes/:name", get(handlers::get_route))
         .with_state(state)
 }
@@ -114,6 +121,44 @@ async fn test_simulate_response_has_fee_fields() {
     assert!(parsed.estimated_fees.total_fee >= parsed.estimated_fees.base_fee);
     assert_eq!(parsed.simulation.target, VALID_CONTRACT_ID);
     assert_eq!(parsed.simulation.function, "transfer");
+}
+
+#[tokio::test]
+async fn test_simulate_rate_limit_headers_and_rejects_after_limit() {
+    let app = test_app();
+    let body = json!({ "target": VALID_CONTRACT_ID, "function": "transfer" });
+    let request = || {
+        Request::builder()
+            .method("POST")
+            .uri("/simulate")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap()
+    };
+
+    for _ in 0..100 {
+        let resp = app
+            .clone()
+            .oneshot(request())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers()["x-rate-limit-limit"], "100");
+    }
+
+    let resp = app
+        .clone()
+        .oneshot(request())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(resp.headers().get("retry-after").is_some());
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["error"].as_str().unwrap(), "rate_limit_exceeded");
 }
 
 #[tokio::test]
@@ -388,10 +433,12 @@ fn test_error_code_serialization() {
 
 /// Helper: create an AppState with a real broadcast channel for WebSocket tests.
 fn ws_app_state() -> AppState {
+    let rate_limiter = RateLimiter::new(RateLimitConfig::default());
     AppState::new(
         "http://localhost:1".to_string(),
         "".to_string(),
         "".to_string(),
+        rate_limiter,
     )
 }
 


### PR DESCRIPTION
closes #655
closes #656 
closes #658 
closes #659 