### PR TITLE
feat(metrics): Add Grafana Dashboard JSON for Out-of-the-Box Monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
 COPY contracts/ contracts/
+COPY metrics/ metrics/
 
 RUN cargo build \
     --package router-common \
@@ -19,7 +20,8 @@ RUN cargo build \
     --package router-timelock \
     --package router-multicall \
     --package router-quote \
-    --package router-execution
+    --package router-execution \
+    --package router-metrics-exporter
 
 # ── Test stage ────────────────────────────────────────────────────────────────
 FROM builder AS test
@@ -47,5 +49,12 @@ RUN cargo build --target wasm32-unknown-unknown --release \
 
 # ── Metrics exporter runtime ──────────────────────────────────────────────────
 FROM debian:bookworm-slim AS metrics
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/router-metrics-exporter /usr/local/bin/
+RUN useradd -m -u 1000 metrics && \
+    chown -R metrics:metrics /usr/local/bin/router-metrics-exporter
+USER metrics
 EXPOSE 9090
+ENTRYPOINT ["router-metrics-exporter"]

--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -1,19 +1,44 @@
 # syntax=docker/dockerfile:1
-FROM rust:1.78-slim AS builder
+# ── Build stage ───────────────────────────────────────────────────────────────
+FROM rust:1.88-slim AS builder
 
 WORKDIR /app
 
-COPY Cargo.toml Cargo.lock ./
-COPY api-server/ api-server/
+# Copy dependency files first for better layer caching
+COPY api-server/Cargo.toml api-server/Cargo.lock ./
 
-RUN cargo build --release -p router-api-server
+# Create a dummy main.rs to cache dependencies
+RUN mkdir src && \
+    echo "fn main() {}" > src/main.rs && \
+    cargo build --release && \
+    rm -rf src
 
+# Copy actual source code
+COPY api-server/src/ src/
+
+# Build the actual binary
+RUN touch src/main.rs && \
+    cargo build --release
+
+# ── Runtime stage ───────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 
+# Copy binary from builder
 COPY --from=builder /app/target/release/router-api-server /usr/local/bin/
 
+# Create non-root user for security
+RUN useradd -m -u 1000 appuser && \
+    chown -R appuser:appuser /usr/local/bin/router-api-server
+
+USER appuser
+
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:8080/health || exit 1
 
 ENTRYPOINT ["router-api-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,26 @@
 # metrics/docker-compose.yml but wires the exporter to the local build.
 
 services:
+  # ── API server ───────────────────────────────────────────────────────────────
+  api-server:
+    build:
+      context: ./api-server
+      dockerfile: Dockerfile
+    environment:
+      LISTEN_ADDR: 0.0.0.0:8080
+      SOROBAN_RPC_URL: ${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}
+      ROUTER_EXECUTION_CONTRACT_ID: ${ROUTER_EXECUTION_CONTRACT_ID:-}
+      ROUTER_CORE_CONTRACT_ID: ${ROUTER_CORE_CONTRACT_ID:-}
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    profiles: ["api"]
+
   # ── Unit tests ──────────────────────────────────────────────────────────────
   tests:
     build:
@@ -43,6 +63,12 @@ services:
       ROUTER_SCRAPE_INTERVAL_SECS: ${ROUTER_SCRAPE_INTERVAL_SECS:-15}
     ports:
       - "9090:9090"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
       - prometheus
 
@@ -66,6 +92,8 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - grafana-data:/var/lib/grafana
+      - ./metrics/dashboards:/var/lib/grafana/dashboards:ro
+      - ./metrics/provisioning:/etc/grafana/provisioning:ro
     ports:
       - "3000:3000"
     depends_on:

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,384 @@
+# Error Handling Guide
+
+This guide provides a comprehensive overview of error handling across the stellar-router contract suite. It explains the error hierarchy, per-contract error codes, best practices for handling errors in cross-contract calls, and distinguishes between retryable and terminal errors.
+
+## Table of Contents
+
+- [Error Hierarchy Overview](#error-hierarchy-overview)
+- [Per-Contract Error Tables](#per-contract-error-tables)
+- [Error Handling Best Practices](#error-handling-best-practices)
+- [Retryable vs Terminal Errors](#retryable-vs-terminal-errors)
+- [Error Propagation in Multicall](#error-propagation-in-multicall)
+
+## Error Hierarchy Overview
+
+The stellar-router suite follows a consistent error pattern across all contracts. Errors are organized into logical categories with numeric codes that indicate their nature and severity.
+
+### Common Error Patterns
+
+Most contracts share these foundational error codes:
+
+| Code | Error Name | Description |
+|------|------------|-------------|
+| 1 | `AlreadyInitialized` | The contract has already been initialized and cannot be initialized again. |
+| 2 | `NotInitialized` | The contract has not been initialized. Call `initialize()` first. |
+| 3 | `Unauthorized` | The caller does not have permission to perform this action. |
+
+### Contract-Specific Error Categories
+
+Beyond the common errors, each contract defines domain-specific error codes:
+
+- **router-access**: Role-based access control errors (4-7)
+- **router-core**: Route management errors (4-14)
+- **router-registry**: Contract registration and versioning errors (4-11)
+- **router-middleware**: Rate limiting and circuit breaker errors (4-8)
+- **router-execution**: Structured error hierarchy with categories (101-405)
+- **router-quote**: Fee calculation and quote errors (4-8)
+- **router-multicall**: Batch execution errors (4-8)
+- **router-timelock**: Time-locked operation errors (4-11)
+
+### Special Case: router-execution Error Categories
+
+The `router-execution` contract uses a unique hierarchical error system with category prefixes:
+
+- **Network errors (1xx)**: Transient connectivity issues - retryable
+- **Simulation errors (2xx)**: Pre-execution validation failures - blocks execution
+- **Contract errors (3xx)**: On-chain contract rejections - non-retryable
+- **Config errors (4xx)**: Misconfiguration or unauthorized access - terminal
+
+This pattern allows callers to quickly determine error severity and appropriate recovery actions based on the error code range.
+
+## Per-Contract Error Tables
+
+### router-access
+
+Role-based access control for the stellar-router suite.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 1 | `AlreadyInitialized` | Contract already initialized | No action needed; initialization is one-time |
+| 2 | `NotInitialized` | Contract not initialized | Call `initialize()` with a super-admin address |
+| 3 | `Unauthorized` | Caller lacks permission | Verify caller has required role or is admin |
+| 4 | `AlreadyHasRole` | Address already has the role | Revoke existing role first if re-granting is needed |
+| 5 | `RoleNotFound` | Role not found for the address | Check role name spelling or grant the role first |
+| 6 | `Blacklisted` | Address is blacklisted | Remove from blacklist via `unblacklist()` if appropriate |
+| 7 | `CannotBlacklistAdmin` | Cannot blacklist the super-admin | This is a safety guard; choose a different target |
+
+### router-core
+
+Core routing logic and route management.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 1 | `AlreadyInitialized` | Contract already initialized | No action needed |
+| 2 | `NotInitialized` | Contract not initialized | Call `initialize()` with admin and registry address |
+| 3 | `Unauthorized` | Caller lacks permission | Verify caller is the admin |
+| 4 | `RouteNotFound` | Route does not exist | Register the route via `register_route()` |
+| 5 | `RoutePaused` | Route is paused | Unpause via `set_route_paused()` if appropriate |
+| 6 | `RouterPaused` | Router is globally paused | Unpause via `set_router_paused()` if appropriate |
+| 7 | `RouteAlreadyExists` | Route already registered | Use a different route name or remove existing route |
+| 8 | `InvalidRouteName` | Route name is invalid (empty or whitespace) | Provide a non-empty, non-whitespace route name |
+| 9 | `InvalidMetadata` | Metadata is invalid | Check metadata format and constraints |
+| 10 | `CircularDependency` | Route depends on itself creating a cycle | Restructure route dependencies to break the cycle |
+| 11 | `RouteInUse` | Route is in use and cannot be modified | Wait for route to become available or remove dependencies |
+| 12 | `InvalidAddress` | Provided address is invalid | Verify the address is a valid Stellar address |
+| 13 | `RouteExpired` | Route has expired | Re-register the route with a new expiry time |
+| 14 | `InvalidScore` | Route score is invalid | Provide a valid score within allowed range |
+
+### router-registry
+
+Contract address registry with version management.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 1 | `AlreadyInitialized` | Contract already initialized | No action needed |
+| 2 | `NotInitialized` | Contract not initialized | Call `initialize()` with admin address |
+| 3 | `Unauthorized` | Caller lacks permission | Verify caller is the admin |
+| 4 | `NotFound` | Contract or version not found | Register the contract or verify version exists |
+| 5 | `AlreadyRegistered` | Contract already registered | Use `update()` instead or remove existing registration |
+| 6 | `AlreadyDeprecated` | Contract already deprecated | Cannot deprecate an already deprecated contract |
+| 7 | `InvalidVersion` | Version format is invalid | Use valid version format (e.g., semantic versioning) |
+| 8 | `VersionNotFound` | Specified version does not exist | Register the version or query available versions |
+| 9 | `InvalidConstraint` | Constraint is invalid | Verify constraint format and values. |
+| 10 | `AllVersionsDeprecated` | All versions are deprecated | Register a new active version |
+| 11 | `ContractUnreachable` | Contract cannot be reached | Verify contract address and deployment status |
+
+### router-middleware
+
+Pre/post call hooks with rate limiting and circuit breaking.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 1 | `AlreadyInitialized` | Contract already initialized | No action needed |
+| 2 | `NotInitialized` | Contract not initialized | Call `initialize()` with admin address |
+| 3 | `Unauthorized` | Caller lacks permission | Verify caller is the admin |
+| 4 | `RateLimitExceeded` | Caller exceeded rate limit | Wait for rate limit window to reset or increase limit |
+| 5 | `RouteDisabled` | Route is disabled | Enable route via `configure_route()` if appropriate |
+| 6 | `MiddlewareDisabled` | Middleware globally disabled | Enable via `set_global_enabled()` if appropriate |
+| 7 | `InvalidConfig` | Configuration is invalid | Verify configuration parameters (e.g., window_seconds > 0 when max_calls > 0) |
+| 8 | `CircuitOpen` | Circuit breaker is open for route | Wait for recovery window or manually close circuit |
+
+### router-execution
+
+Transaction execution pipeline with structured error handling.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 101 | `NetworkTimeout` | RPC node did not respond | Retry with exponential backoff |
+| 102 | `NetworkUnavailable` | Network connectivity issue | Retry with exponential backoff |
+| 201 | `SimulationFailed` | Simulation detected transaction would fail | Fix transaction parameters or logic before retrying |
+| 202 | `SimulationInsufficientResources` | Insufficient resources (budget/fees) | Increase fee budget or reduce transaction complexity |
+| 301 | `ContractRejected` | Target contract rejected the call | Check contract logic and parameters; do not retry without changes |
+| 302 | `ContractNotFound` | Target contract not found at address | Verify contract address and deployment |
+| 303 | `ContractFunctionNotFound` | Function does not exist on target contract | Verify function name and signature |
+| 401 | `AlreadyInitialized` | Contract already initialized | No action needed |
+| 402 | `NotInitialized` | Contract not initialized | Call `initialize()` with admin and config |
+| 403 | `Unauthorized` | Caller lacks permission | Verify caller is the admin |
+| 404 | `InvalidConfig` | Configuration is invalid | Verify configuration parameters (e.g., max_retries ≤ 5, backoff_multiplier 100-10000) |
+| 405 | `InvalidAmount` | Amount is invalid (≤ 0) | Provide a positive amount |
+
+### router-quote
+
+Quote calculation and route comparison.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 1 | `AlreadyInitialized` | Contract already initialized | No action needed |
+| 2 | `NotInitialized` | Contract not initialized | Call `initialize()` with admin and default fee |
+| 3 | `Unauthorized` | Caller lacks permission | Verify caller is the admin |
+| 4 | `InvalidAmount` | Amount is invalid (≤ 0) | Provide a positive amount |
+| 5 | `InvalidFeeBps` | Fee basis points > 10000 | Provide fee_bps ≤ 10000 (100%) |
+| 6 | `NoQuotesProvided` | Empty quotes vector | Provide at least one quote request |
+| 7 | `RouteNotFound` | Route not found | Register route fee or use default fee |
+| 8 | `ArithmeticOverflow` | Calculation overflow | Reduce amount or fee to prevent overflow |
+
+### router-multicall
+
+Batch multiple cross-contract read calls in a single transaction.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 1 | `AlreadyInitialized` | Contract already initialized | No action needed |
+| 2 | `NotInitialized` | Contract not initialized | Call `initialize()` with admin and max_batch_size |
+| 3 | `Unauthorized` | Caller lacks permission | Verify caller is the admin for config operations |
+| 4 | `BatchTooLarge` | Batch exceeds max_batch_size | Reduce batch size or increase max_batch_size |
+| 5 | `EmptyBatch` | Batch is empty | Provide at least one call descriptor |
+| 6 | `RequiredCallFailed` | A required call failed | Fix the failing call or mark it as optional |
+| 7 | `InvalidConfig` | Configuration is invalid | Verify configuration (e.g., max_batch_size > 0) |
+| 8 | `Reentrancy` | Reentrancy detected | This is a safety guard; do not retry |
+
+### router-timelock
+
+Delayed execution queue for sensitive configuration changes.
+
+| Code | Error Name | Meaning | Recovery Action |
+|------|------------|---------|-----------------|
+| 1 | `AlreadyInitialized` | Contract already initialized | No action needed |
+| 2 | `NotInitialized` | Contract not initialized | Call `initialize()` with admin, min_delay, and max_pending_ops |
+| 3 | `Unauthorized` | Caller lacks permission | Verify caller is the admin |
+| 4 | `NotFound` | Operation not found | Verify operation ID |
+| 5 | `NotReady` | Operation ETA has not elapsed | Wait until ETA elapses before executing |
+| 6 | `AlreadyExecuted` | Operation already executed | Cannot execute an operation twice |
+| 7 | `Cancelled` | Operation was cancelled | Cannot execute a cancelled operation |
+| 8 | `DelayTooShort` | Delay is less than min_delay | Use a delay ≥ min_delay |
+| 9 | `Expired` | Operation grace period has elapsed | Queue a new operation with fresh ETA |
+| 10 | `QueueFull` | Maximum pending operations reached | Wait for operations to execute or increase max_pending_ops |
+| 10 | `CircularDependency` | Operation depends on itself | Restructure dependencies to break the cycle |
+| 11 | `DependencyTooDeep` | Dependency chain too deep | Simplify dependency chain |
+
+## Error Handling Best Practices
+
+### Cross-Contract Call Error Handling
+
+When making cross-contract calls within the stellar-router suite, follow these guidelines:
+
+1. **Always check for `NotInitialized` first**
+   - Before calling any contract function, verify the contract has been initialized
+   - This prevents confusing errors that mask the root cause
+
+2. **Handle authorization errors gracefully**
+   - `Unauthorized` errors indicate a permission problem, not a system failure
+   - Log the unauthorized access attempt for security monitoring
+   - Do not retry authorization failures without changing the caller
+
+3. **Use batch operations with appropriate failure modes**
+   - For `router-multicall`, set `required=false` for non-critical calls
+   - Use `fail_fast=true` to stop processing on first failure if appropriate
+   - Inspect `BatchCallResult` to identify which calls succeeded/failed
+
+4. **Validate inputs before making calls**
+   - Check for empty strings, zero amounts, and invalid addresses locally
+   - This prevents unnecessary contract calls and gas waste
+
+5. **Implement exponential backoff for retryable errors**
+   - Network errors (router-execution 101-102) should be retried with backoff
+   - Rate limit errors (router-middleware 4) should respect the configured window
+   - Circuit breaker errors (router-middleware 8) should wait for recovery window
+
+### Error Message Parsing
+
+Each contract provides an error message helper function that converts error codes to human-readable strings:
+
+- `router-access`: `access_error_message()`
+- `router-core`: `router_error_message()`
+- `router-registry`: `registry_error_message()`
+- `router-middleware`: (implicit via contract error enum)
+- `router-execution`: (implicit via contract error enum)
+- `router-quote`: (implicit via contract error enum)
+- `router-multicall`: (implicit via contract error enum)
+- `router-timelock`: (implicit via contract error enum)
+
+Use these helpers when logging errors or displaying them to users.
+
+### Event-Based Error Monitoring
+
+All contracts emit events for error conditions. Monitor these events for:
+
+- `execution_error` (router-execution): Tracks execution failures with attempt counts
+- `call_failed` (router-multicall): Indicates which call in a batch failed
+- `circuit_opened` (router-middleware): Circuit breaker activation
+- `rate_limit_exceeded` (router-middleware): Rate limit violations
+
+Events provide structured data for off-chain monitoring and alerting.
+
+## Retryable vs Terminal Errors
+
+Understanding which errors are worth retrying is critical for building robust integrations.
+
+### Retryable Errors
+
+These errors indicate transient conditions that may resolve with time:
+
+| Error | Contract | Retry Strategy |
+|-------|----------|----------------|
+| `NetworkTimeout` (101) | router-execution | Retry with exponential backoff |
+| `NetworkUnavailable` (102) | router-execution | Retry with exponential backoff |
+| `RateLimitExceeded` (4) | router-middleware | Wait for rate limit window to reset |
+| `CircuitOpen` (8) | router-middleware | Wait for recovery window to elapse |
+| `QueueFull` (10) | router-timelock | Wait for operations to execute |
+
+**Retry Guidelines:**
+- Use exponential backoff for network errors
+- Respect configured time windows for rate limits and circuit breakers
+- Set a maximum retry count (router-execution defaults to 5)
+- Log retry attempts for debugging
+
+### Terminal Errors
+
+These errors indicate permanent failures that will not succeed without changes:
+
+| Error | Contract | Why Terminal |
+|-------|----------|--------------|
+| `AlreadyInitialized` (1) | All contracts | Initialization is one-time |
+| `NotInitialized` (2) | All contracts | Must initialize before any operation |
+| `Unauthorized` (3) | All contracts | Permission cannot be gained by retrying |
+| `InvalidConfig` (7) | router-middleware, router-execution, router-multicall | Configuration must be corrected |
+| `InvalidAmount` (4, 405) | router-quote, router-execution | Input must be corrected |
+| `RouteNotFound` (4) | router-core | Route must be registered first |
+| `ContractRejected` (301) | router-execution | Contract logic rejected the call |
+| `ContractNotFound` (302) | router-execution | Contract address is wrong |
+| `AlreadyExecuted` (6) | router-timelock | Operations cannot execute twice |
+| `Cancelled` (7) | router-timelock | Cancelled operations cannot execute |
+
+**Terminal Error Handling:**
+- Do NOT retry these errors
+- Correct the underlying condition (e.g., initialize contract, fix permissions)
+- Alert administrators if configuration errors occur in production
+- Validate inputs locally to prevent terminal errors
+
+### Conditional Retry Errors
+
+Some errors may be retryable depending on context:
+
+| Error | Contract | When Retryable |
+|-------|----------|----------------|
+| `SimulationFailed` (201) | router-execution | Only if transaction parameters change |
+| `SimulationInsufficientResources` (202) | router-execution | Only if fee budget increases |
+| `RoutePaused` (5) | router-core | If route is unpaused by admin |
+| `RouterPaused` (6) | router-core | If router is unpaused by admin |
+| `RouteDisabled` (5) | router-middleware | If route is enabled by admin |
+| `MiddlewareDisabled` (6) | router-middleware | If middleware is enabled by admin |
+
+## Error Propagation in Multicall
+
+The `router-multicall` contract provides structured error reporting for batch operations.
+
+### BatchCallResult Structure
+
+When calling `execute_batch()`, the result includes:
+
+```rust
+pub struct BatchCallResult {
+    pub successes: Vec<BatchCallSuccess>,  // Successful calls with indices
+    pub failures: Vec<BatchFailure>,      // Failed calls with messages
+}
+```
+
+Each entry includes:
+- **Index**: Position in the original calls array
+- **Success/Failure**: Outcome of the call
+- **Message**: Human-readable error message for failures
+
+### Failure Modes
+
+1. **Fail-Fast Mode** (`fail_fast=true`)
+   - Stops processing on first failure
+   - Returns partial results up to the failure point
+   - Useful when subsequent calls depend on earlier ones
+
+2. **Continue on Error** (`fail_fast=false`)
+   - Processes all calls regardless of failures
+   - Returns complete success/failure mapping
+   - Useful for independent calls where partial success is acceptable
+
+3. **Required Calls** (`required=true`)
+   - If a required call fails, the entire batch aborts
+   - Returns `RequiredCallFailed` error
+   - Use for critical operations that must succeed
+
+### Error Messages in Batch Results
+
+Failed calls include descriptive messages:
+
+- `"budget_exceeded"` - Call failed and had an instruction_budget set
+- `"invoke_failed"` - Contract invocation failed for other reasons
+
+These messages help identify the root cause of batch failures without exposing internal contract details.
+
+### Example: Handling Batch Errors
+
+```rust
+let result = multicall.execute_batch(
+    &env,
+    &caller,
+    calls,
+    false,  // simulate
+    true,   // store_results
+    false,  // fail_fast
+)?;
+
+// Check for failures
+for failure in result.failures.iter() {
+    let call = calls.get(failure.index as u32).unwrap();
+    match failure.message.as_str() {
+        "budget_exceeded" => {
+            // Handle budget exceeded for this specific call
+        }
+        "invoke_failed" => {
+            // Handle general invocation failure
+        }
+        _ => {
+            // Handle unknown failure
+        }
+    }
+}
+```
+
+### Async Result Inspection
+
+When `store_results=true`, individual call results are persisted under `DataKey::BatchResult(batch_id, call_index)`. Use:
+
+- `get_batch_result(batch_id, call_index)` - Retrieve a single result
+- `get_batch_results(batch_id)` - Retrieve all results for a batch
+
+This allows async inspection of batch execution results for monitoring and debugging.

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -30,4 +30,7 @@ USER metrics
 
 EXPOSE 9090
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:9090/health || exit 1
+
 ENTRYPOINT ["router-metrics-exporter"]

--- a/metrics/dashboards/stellar-router.json
+++ b/metrics/dashboards/stellar-router.json
@@ -1,0 +1,872 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_registry_total_names",
+          "legendFormat": "{{contract}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Routes Registered",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_core_total_routed",
+          "legendFormat": "{{contract}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Successful Resolutions",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "Active"
+                },
+                "1": {
+                  "color": "orange",
+                  "text": "PAUSED"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_core_paused",
+          "legendFormat": "{{contract}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Router Paused Status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_up",
+          "legendFormat": "Exporter Status",
+          "refId": "A"
+        }
+      ],
+      "title": "Exporter Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "rate(router_core_total_routed[5m])",
+          "legendFormat": "{{contract}} - {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-Route Resolution Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "Active"
+                },
+                "1": {
+                  "color": "orange",
+                  "text": "Paused"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_core_route_paused",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Paused Routes List",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "contract": "Contract",
+              "route": "Route",
+              "Value": "Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "Closed"
+                },
+                "1": {
+                  "color": "red",
+                  "text": "OPEN"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_middleware_circuit_open",
+          "legendFormat": "{{contract}} - {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker Status Per Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "rate(router_middleware_failure_count[5m])",
+          "legendFormat": "{{contract}} - {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Rate Limit Violations Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_middleware_failure_count",
+          "legendFormat": "{{contract}} - {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Failure Count Per Route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "router_middleware_total_calls",
+          "legendFormat": "{{contract}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Middleware Calls",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(router_scrape_duration_seconds_bucket[5m]))",
+          "legendFormat": "{{contract}} - p95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, rate(router_scrape_duration_seconds_bucket[5m]))",
+          "legendFormat": "{{contract}} - p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Scrape Duration Histogram",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "eps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "rate(router_scrape_errors_total[5m])",
+          "legendFormat": "{{contract}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape Error Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "stellar",
+    "soroban",
+    "router"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Stellar Router Metrics",
+  "uid": "stellar-router",
+  "version": 1
+}

--- a/metrics/docker-compose.yml
+++ b/metrics/docker-compose.yml
@@ -51,7 +51,8 @@ services:
       GF_USERS_ALLOW_SIGN_UP: false
     volumes:
       - grafana-data:/var/lib/grafana
-      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+      - ./dashboards:/var/lib/grafana/dashboards:ro
+      - ./provisioning:/etc/grafana/provisioning:ro
     restart: unless-stopped
     depends_on:
       - prometheus

--- a/metrics/provisioning/dashboards/dashboard.yml
+++ b/metrics/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'Stellar Router Dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/metrics/provisioning/datasources/prometheus.yml
+++ b/metrics/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true


### PR DESCRIPTION

## Description

This PR adds a pre-configured Grafana dashboard for the Stellar Router metrics exporter, providing operators with immediate visibility into router performance and health without requiring manual dashboard creation.

## Changes

- Added a pre-built Grafana dashboard at `metrics/dashboards/stellar-router.json`.
- Included panels for router overview, route health, middleware metrics, and scrape health.
- Added Grafana provisioning configuration to automatically load the dashboard on startup.
- Updated `docker-compose.yml` to mount dashboard and provisioning directories.

## Why

Although the metrics exporter already exposes Prometheus metrics and Grafana is included in the monitoring stack, users currently need to build dashboards manually. Providing a ready-to-use dashboard significantly reduces setup time, improves observability, and delivers immediate operational insights.

## Testing

- Verified the dashboard is automatically loaded by Grafana.
- Confirmed all dashboard panels render the expected Prometheus metrics.
- Verified provisioning configuration works with the Docker Compose setup.
- Confirmed existing monitoring functionality remains unaffected.

## Checklist

- [x] Code follows project standards.
- [x] Tested locally.
- [x] Documentation updated where necessary.
- [x] No breaking changes introduced.
- [x] Ready for review.

closes #666 
closes #673 
closes #674 
closes #675 