### PR TITLE
test(router-multicall): add reentrancy guard cleanup test for empty batch

### DIFF
--- a/contracts/router-multicall/src/lib.rs
+++ b/contracts/router-multicall/src/lib.rs
@@ -559,6 +559,23 @@ mod tests {
         assert_eq!(result, Err(Ok(MulticallError::EmptyBatch)));
     }
 
+    /// Verifies that the reentrancy guard is cleared after an empty batch failure (closes #725).
+    /// A second call to execute_batch must not return Reentrancy.
+    #[test]
+    fn test_empty_batch_clears_reentrancy_guard() {
+        let (env, _admin, client) = setup();
+        let caller = Address::generate(&env);
+        let calls: Vec<CallDescriptor> = Vec::new(&env);
+
+        // First call: must fail with EmptyBatch
+        let first = client.try_execute_batch(&caller, &calls, &false, &false, &false);
+        assert_eq!(first, Err(Ok(MulticallError::EmptyBatch)));
+
+        // Second call: must also fail with EmptyBatch, not Reentrancy
+        let second = client.try_execute_batch(&caller, &calls, &false, &false, &false);
+        assert_eq!(second, Err(Ok(MulticallError::EmptyBatch)));
+    }
+
     #[test]
     fn test_batch_too_large_fails() {
         let (env, admin, client) = setup();


### PR DESCRIPTION
## Summary

Closes #725

The existing `test_empty_batch_fails` only asserts that `MulticallError::EmptyBatch` is returned when calling `execute_batch` with an empty `Vec`. It does not verify that the reentrancy guard (`DataKey::Executing`) is properly removed in that code path.

## What was added

`test_empty_batch_clears_reentrancy_guard` — calls `execute_batch` twice in sequence with an empty batch. The second call must return `EmptyBatch` (not `Reentrancy`), proving that `env.storage().instance().remove(&DataKey::Executing)` is executed before the early return at line 187–188.

## Testing

- First call → `Err(EmptyBatch)` ✓
- Second call → `Err(EmptyBatch)` ✓ (not `Err(Reentrancy)`)