### PR TITLE
feat(router-middleware): add burst_allowance to RouteConfig

### DIFF
--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -83,6 +83,8 @@ pub struct RouteConfig {
     pub recovery_window_seconds: u64,
     /// Max call log entries to keep (0 = disabled)
     pub log_retention: u32,
+    /// Extra calls allowed above max_calls_per_window before rejection (0 = no burst)
+    pub burst_allowance: u32,
 }
 
 #[contracttype]
@@ -245,6 +247,7 @@ impl RouterMiddleware {
         failure_threshold: u32,
         recovery_window_seconds: u64,
         log_retention: u32,
+        burst_allowance: u32,
     ) -> Result<(), MiddlewareError> {
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, MiddlewareError)?;
@@ -264,6 +267,7 @@ impl RouterMiddleware {
             failure_threshold,
             recovery_window_seconds,
             log_retention,
+            burst_allowance,
         };
         env.storage()
             .instance()
@@ -1502,7 +1506,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // Enable route with a rate limit of 5 calls per window
-        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
 
@@ -1512,7 +1516,7 @@ mod tests {
         assert_eq!(state_after_first.calls_in_window, 1);
 
         // Disable the route
-        client.configure_route(&admin, &route, &5, &60, &false, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &false, &0, &0, &0, &0);
 
         // pre_call must be rejected — RouteDisabled
         assert_eq!(
@@ -1528,7 +1532,7 @@ mod tests {
         assert_eq!(client.total_calls(), 1);
 
         // Re-enable the route — no stale state should affect the next call
-        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
         assert!(client.try_pre_call(&caller, &route).is_ok());
         let state_after_reenable = client.rate_limit_state(&route, &caller).unwrap();
         assert_eq!(state_after_reenable.calls_in_window, 2);
@@ -1538,7 +1542,7 @@ mod tests {
     fn test_global_disable_does_not_write_rate_limit_state() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         // One successful call
@@ -1573,7 +1577,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // max 2 calls per 60s window
-        client.configure_route(&admin, &route, &2, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &2, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         client.pre_call(&caller, &route);
@@ -1586,7 +1590,7 @@ mod tests {
     fn test_rate_limit_resets_after_window() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         client.pre_call(&caller, &route);
@@ -1600,7 +1604,7 @@ mod tests {
     fn test_disabled_route_blocked() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &false, &0, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &false, &0, &0, &0, &0);
         let caller = Address::generate(&env);
         let result = client.try_pre_call(&caller, &route);
         assert_eq!(result, Err(Ok(MiddlewareError::RouteDisabled)));
@@ -1621,7 +1625,7 @@ mod tests {
         let (env, _admin, client) = setup();
         let attacker = Address::generate(&env);
         let route = String::from_str(&env, "oracle/get_price");
-        let result = client.try_configure_route(&attacker, &route, &10, &60, &true, &0, &0, &0);
+        let result = client.try_configure_route(&attacker, &route, &10, &60, &true, &0, &0, &0, &0);
         assert_eq!(result, Err(Ok(MiddlewareError::Unauthorized)));
     }
 
@@ -1640,7 +1644,7 @@ mod tests {
     fn test_get_call_log_length_zero_before_calls() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3, &0);
 
         assert_eq!(client.get_call_log_length(&route), 0);
     }
@@ -1650,7 +1654,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5, &0);
 
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &false);
@@ -1666,7 +1670,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &2);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &2, &0);
 
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &false);
@@ -1682,8 +1686,8 @@ mod tests {
         let route_a = String::from_str(&env, "oracle/price");
         let route_b = String::from_str(&env, "vault/deposit");
         // route_a: 10 calls per minute, route_b: 5 calls per minute
-        client.configure_route(&admin, &route_a, &10, &60, &true, &0, &0, &0);
-        client.configure_route(&admin, &route_b, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route_a, &10, &60, &true, &0, &0, &0, &0);
+        client.configure_route(&admin, &route_b, &5, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         // Make 4 calls on route_a — drains route_a counter to 4
@@ -1708,7 +1712,7 @@ mod tests {
     fn test_total_calls_not_incremented_on_rejected_pre_call() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         client.pre_call(&caller, &route); // passes, total = 1
@@ -1747,7 +1751,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // Configure route with failure_threshold = 1, no recovery window for simplicity
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0, &0);
 
         let caller = Address::generate(&env);
         // First call succeeds
@@ -1763,7 +1767,7 @@ mod tests {
     fn test_reset_circuit_breaker() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0, &0);
 
         let caller = Address::generate(&env);
         client.pre_call(&caller, &route);
@@ -1827,7 +1831,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // threshold=3, so 2 failures then a success then 2 more should NOT trip
-        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0, &0);
         let caller = Address::generate(&env);
 
         client.post_call(&caller, &route, &false); // failure_count = 1
@@ -1845,7 +1849,7 @@ mod tests {
     fn test_open_circuit_not_reset_by_success() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0, &0);
         let caller = Address::generate(&env);
 
         client.post_call(&caller, &route, &false); // trips circuit (threshold=1)
@@ -1872,8 +1876,8 @@ mod tests {
         let (env, admin, client) = setup();
         let route_a = String::from_str(&env, "oracle/price");
         let route_b = String::from_str(&env, "vault/deposit");
-        client.configure_route(&admin, &route_a, &0, &0, &true, &0, &0, &0);
-        client.configure_route(&admin, &route_b, &0, &0, &true, &0, &0, &0);
+        client.configure_route(&admin, &route_a, &0, &0, &true, &0, &0, &0, &0);
+        client.configure_route(&admin, &route_b, &0, &0, &true, &0, &0, &0, &0);
         let routes = client.get_configured_routes();
         assert_eq!(routes.len(), 2);
         assert!(routes.contains(&route_a));
@@ -1884,8 +1888,8 @@ mod tests {
     fn test_get_configured_routes_no_duplicates() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/price");
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0);
-        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
         let routes = client.get_configured_routes();
         assert_eq!(routes.len(), 1);
     }
@@ -1896,7 +1900,7 @@ mod tests {
     fn test_circuit_breaker_state_none_before_failures() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0, &0);
         assert_eq!(client.circuit_breaker_state(&route), None);
     }
 
@@ -1904,7 +1908,7 @@ mod tests {
     fn test_circuit_breaker_state_reflects_failures() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &3, &0, &0, &0);
         let caller = Address::generate(&env);
         client.post_call(&caller, &route, &false);
         let state = client.circuit_breaker_state(&route).unwrap();
@@ -1916,7 +1920,7 @@ mod tests {
     fn test_circuit_breaker_state_open_after_threshold() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &2, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &2, &0, &0, &0);
         let caller = Address::generate(&env);
         client.post_call(&caller, &route, &false);
         client.post_call(&caller, &route, &false);
@@ -1929,7 +1933,7 @@ mod tests {
     fn test_circuit_breaker_state_clears_after_reset() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &0, &0, &0);
         let caller = Address::generate(&env);
         client.post_call(&caller, &route, &false);
         assert!(client.circuit_breaker_state(&route).unwrap().is_open);
@@ -1944,7 +1948,7 @@ mod tests {
     fn test_call_log_never_exceeds_retention() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3, &0);
 
         let caller = Address::generate(&env);
         for _ in 0..10 {
@@ -1959,7 +1963,7 @@ mod tests {
     fn test_call_log_retains_most_recent() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3, &0);
 
         let caller = Address::generate(&env);
         // Make 5 calls with distinct timestamps so we can identify order
@@ -1984,7 +1988,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // Configure route with 60 second window and max 5 calls
-        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
 
@@ -2014,7 +2018,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // Configure route with 60 second window
-        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
 
@@ -2043,7 +2047,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // failure_threshold=1, recovery_window=60s
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0, &0);
 
         let caller = Address::generate(&env);
 
@@ -2065,7 +2069,7 @@ mod tests {
     fn test_circuit_not_recovered_before_window_elapses() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0, &0);
 
         let caller = Address::generate(&env);
         client.post_call(&caller, &route, &false);
@@ -2083,7 +2087,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // failure_threshold=1, recovery_window=60s
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0, &0);
 
         let caller = Address::generate(&env);
 
@@ -2123,7 +2127,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/price");
         // max 1 call per 60s window
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         let t0 = env.ledger().timestamp();
@@ -2147,7 +2151,7 @@ mod tests {
         // Ledger timestamp jumps several windows at once; counter must reset.
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/price");
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         let t0 = env.ledger().timestamp();
@@ -2170,7 +2174,7 @@ mod tests {
         // window_seconds=0 and max_calls=0 means unlimited (no rate limiting).
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/price");
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         // Many calls should all succeed
@@ -2202,7 +2206,7 @@ mod tests {
     fn test_get_call_log_filtered_empty_when_no_calls() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10, &0);
 
         assert!(client.get_call_log_filtered(&route, &true).is_empty());
         assert!(client.get_call_log_filtered(&route, &false).is_empty());
@@ -2213,7 +2217,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10, &0);
 
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &false);
@@ -2230,7 +2234,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10, &0);
 
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &false);
@@ -2247,7 +2251,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5, &0);
 
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &true);
@@ -2262,7 +2266,7 @@ mod tests {
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
         // retention=3, make 5 calls so ring buffer wraps
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &3, &0);
 
         client.post_call(&caller, &route, &true); // evicted
         client.post_call(&caller, &route, &false); // evicted
@@ -2283,7 +2287,7 @@ mod tests {
     fn test_get_call_log_summary_none_before_calls() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5, &0);
         assert_eq!(client.get_call_log_summary(&route), None);
     }
 
@@ -2292,7 +2296,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10, &0);
 
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &true);
@@ -2309,7 +2313,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &10, &0);
 
         env.ledger().set_timestamp(1000);
         client.post_call(&caller, &route, &true);
@@ -2326,7 +2330,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let caller = Address::generate(&env);
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &2); // retain only 2
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &2, &0); // retain only 2
 
         for _ in 0..5 {
             client.post_call(&caller, &route, &true);
@@ -2346,7 +2350,7 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with failure_threshold=3
-        client.configure_route(&admin, &route, &0, &0, &true, &3, &60, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &3, &60, &0, &0);
 
         // Trigger 3 failures to reach threshold
         client.post_call(&caller, &route, &false);
@@ -2365,7 +2369,7 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with failure_threshold=1, recovery_window=60s
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0, &0);
 
         // Trip the circuit
         client.post_call(&caller, &route, &false);
@@ -2394,7 +2398,7 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with failure_threshold=2, recovery_window=100s
-        client.configure_route(&admin, &route, &0, &0, &true, &2, &100, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &2, &100, &0, &0);
 
         // Trip the circuit
         client.post_call(&caller, &route, &false);
@@ -2424,7 +2428,7 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with failure_threshold=2, recovery_window=60s
-        client.configure_route(&admin, &route, &0, &0, &true, &2, &60, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &2, &60, &0, &0);
 
         // Trip the circuit
         client.post_call(&caller, &route, &false);
@@ -2456,7 +2460,7 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with failure_threshold=1, recovery_window=50s
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &50, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &50, &0, &0);
 
         // Trip the circuit
         client.post_call(&caller, &route, &false);
@@ -2491,7 +2495,7 @@ mod tests {
         let caller = Address::generate(&env);
 
         // failure_threshold=1, recovery_window=60s
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &60, &0, &0);
 
         // Trip the circuit
         client.post_call(&caller, &route, &false);
@@ -2537,7 +2541,7 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with failure_threshold=1, recovery_window=100s
-        client.configure_route(&admin, &route, &0, &0, &true, &1, &100, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &1, &100, &0, &0);
 
         // Trip the circuit
         client.post_call(&caller, &route, &false);
@@ -2564,7 +2568,7 @@ mod tests {
     fn test_rate_limit_strategy_default_is_reject() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         // Without setting a strategy, default should be Reject
         let caller = Address::generate(&env);
@@ -2611,7 +2615,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // max 1 call per 60s window
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
         client.set_rate_limit_strategy(&admin, &route, &RateLimitStrategy::Throttle);
 
         let caller = Address::generate(&env);
@@ -2627,7 +2631,7 @@ mod tests {
     fn test_throttle_strategy_emits_event() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
         client.set_rate_limit_strategy(&admin, &route, &RateLimitStrategy::Throttle);
 
         let caller = Address::generate(&env);
@@ -2656,7 +2660,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         // max 1 call per 60s window
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
         client.set_rate_limit_strategy(&admin, &route, &RateLimitStrategy::LogOnly);
 
         let caller = Address::generate(&env);
@@ -2673,7 +2677,7 @@ mod tests {
     fn test_log_only_strategy_emits_event() {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
         client.set_rate_limit_strategy(&admin, &route, &RateLimitStrategy::LogOnly);
 
         let caller = Address::generate(&env);
@@ -2704,8 +2708,8 @@ mod tests {
         let route_b = String::from_str(&env, "vault/deposit");
 
         // Both routes have max 1 call per window
-        client.configure_route(&admin, &route_a, &1, &60, &true, &0, &0, &0);
-        client.configure_route(&admin, &route_b, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route_a, &1, &60, &true, &0, &0, &0, &0);
+        client.configure_route(&admin, &route_b, &1, &60, &true, &0, &0, &0, &0);
 
         // route_a: Throttle (allows), route_b: Reject (default, blocks)
         client.set_rate_limit_strategy(&admin, &route_a, &RateLimitStrategy::Throttle);
@@ -2754,7 +2758,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         env.ledger().set_timestamp(100);
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         client.pre_call(&caller, &route);
@@ -2778,7 +2782,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let t0 = env.ledger().timestamp();
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         client.pre_call(&caller, &route);
@@ -2800,7 +2804,7 @@ mod tests {
         // Multiple calls at the same ledger timestamp must each be counted
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
-        client.configure_route(&admin, &route, &3, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &3, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         let ts = env.ledger().timestamp();
@@ -2825,7 +2829,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         let t0 = env.ledger().timestamp();
-        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &1, &60, &true, &0, &0, &0, &0);
 
         let caller_a = Address::generate(&env);
         let caller_b = Address::generate(&env);
@@ -2852,7 +2856,7 @@ mod tests {
         let (env, admin, client) = setup();
         let route = String::from_str(&env, "oracle/get_price");
         env.ledger().set_timestamp(10000);
-        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
 
         let caller = Address::generate(&env);
         client.pre_call(&caller, &route); // window_start = 10000
@@ -2876,12 +2880,12 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with retention=5, make some calls
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5, &0);
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &false);
 
         // Reconfigure with retention=0 (logging disabled)
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0, &0);
 
         // get_call_log must not panic; should return empty
         let log = client.get_call_log(&route);
@@ -2895,17 +2899,33 @@ mod tests {
         let caller = Address::generate(&env);
 
         // Configure with retention=5, make some calls
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5, &0);
         client.post_call(&caller, &route, &true);
         client.post_call(&caller, &route, &false);
 
         // Reconfigure with retention=0 (logging disabled)
-        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0);
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &0, &0);
 
         // get_call_log_filtered must not panic; should return empty
         let log = client.get_call_log_filtered(&route, &true);
         assert_eq!(log.len(), 0);
         let log = client.get_call_log_filtered(&route, &false);
         assert_eq!(log.len(), 0);
+    }
+
+    #[test]
+    fn test_burst_allowance_permits_extra_calls() {
+        let (env, admin, client) = setup();
+        let caller = Address::generate(&env);
+        let route = String::from_str(&env, "oracle/get_price");
+
+        // max=2, burst=1 → 3 calls allowed before rejection
+        client.configure_route(&admin, &route, &2, &60, &true, &0, &0, &0, &1);
+
+        client.pre_call(&caller, &route); // call 1
+        client.pre_call(&caller, &route); // call 2 (at max)
+        client.pre_call(&caller, &route); // call 3 (burst)
+        let result = client.try_pre_call(&caller, &route); // call 4 → rejected
+        assert_eq!(result, Err(Ok(MiddlewareError::RateLimitExceeded)));
     }
 }

--- a/contracts/router-middleware/src/rate_limit.rs
+++ b/contracts/router-middleware/src/rate_limit.rs
@@ -45,7 +45,7 @@ pub fn check_and_increment(
         state.window_start
     };
 
-    if calls >= config.max_calls_per_window {
+    if calls >= config.max_calls_per_window + config.burst_allowance {
         // Record violation without incrementing the call count
         let mut violation_state = state.clone();
         violation_state.total_violations = violation_state.total_violations.saturating_add(1);


### PR DESCRIPTION
Closes #724

## Summary
Adds an optional `burst_allowance: u32` field to `RouteConfig` so legitimate bursty workloads can exceed `max_calls_per_window` by up to `burst_allowance` extra calls before being rejected.

## Changes
- `RouteConfig` gains `burst_allowance: u32` (0 = no burst, preserves existing behaviour)
- `configure_route` accepts the new parameter
- `check_and_increment` enforces `max_calls_per_window + burst_allowance` as the effective cap
- New test: `test_burst_allowance_permits_extra_calls`
- All existing `configure_route` test calls updated with `burst_allowance = 0`