### PR TITLE
feat(router-common): add BatchItemError enum for structured batch failures

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -85,7 +85,7 @@ impl RouterAccess {
             match Self::grant_role_internal(&env, &account, &role, expires_in) {
                 Ok(()) => result.record_success(idx),
                 Err(err) => {
-                    result.record_failure(&env, idx, Self::access_error_message(err));
+                    result.record_failure(idx, Self::access_error_to_batch(&env, err));
                     if fail_fast {
                         break;
                     }
@@ -358,15 +358,14 @@ impl RouterAccess {
         }
     }
 
-    fn access_error_message(err: AccessError) -> &'static str {
+    fn access_error_to_batch(env: &Env, err: AccessError) -> router_common::BatchItemError {
         match err {
-            AccessError::AlreadyInitialized => "AlreadyInitialized",
-            AccessError::NotInitialized => "NotInitialized",
-            AccessError::Unauthorized => "Unauthorized",
-            AccessError::AlreadyHasRole => "AlreadyHasRole",
-            AccessError::RoleNotFound => "RoleNotFound",
-            AccessError::Blacklisted => "Blacklisted",
-            AccessError::CannotBlacklistAdmin => "CannotBlacklistAdmin",
+            AccessError::AlreadyHasRole => router_common::BatchItemError::AlreadyExists,
+            AccessError::Unauthorized => router_common::BatchItemError::Unauthorized,
+            AccessError::Blacklisted => router_common::BatchItemError::InvalidMetadata,
+            _ => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "Error"),
+            ),
         }
     }
 
@@ -1020,8 +1019,8 @@ mod tests {
         assert_eq!(result.failures.len(), 2);
         assert_eq!(result.failures.get(0).unwrap().index, 0);
         assert_eq!(
-            result.failures.get(0).unwrap().message,
-            String::from_str(&env, "AlreadyHasRole")
+            result.failures.get(0).unwrap().error,
+            router_common::BatchItemError::AlreadyExists
         );
     }
 

--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -254,12 +254,26 @@ pub struct BatchCallSuccess {
     pub result: CallResult,
 }
 
+/// Structured error variants for batch item failures.
+///
+/// Clients can match on these variants instead of string-comparing error messages,
+/// enabling reliable programmatic error handling across contract versions.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum BatchItemError {
+    AlreadyExists,
+    InvalidName,
+    Unauthorized,
+    InvalidMetadata,
+    Custom(String),
+}
+
 /// Indexed failure entry for batch operations.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct BatchFailure {
     pub index: u32,
-    pub message: String,
+    pub error: BatchItemError,
 }
 
 /// Standardized per-index batch operation result for void operations (`T = BatchUnit`).
@@ -290,11 +304,8 @@ impl BatchResult {
         self.successes.push_back(BatchSuccess { index });
     }
 
-    pub fn record_failure(&mut self, env: &Env, index: u32, message: &str) {
-        self.failures.push_back(BatchFailure {
-            index,
-            message: String::from_str(env, message),
-        });
+    pub fn record_failure(&mut self, index: u32, error: BatchItemError) {
+        self.failures.push_back(BatchFailure { index, error });
     }
 
     pub fn has_failures(&self) -> bool {
@@ -317,11 +328,8 @@ impl BatchCallResult {
         });
     }
 
-    pub fn record_failure(&mut self, env: &Env, index: u32, message: &str) {
-        self.failures.push_back(BatchFailure {
-            index,
-            message: String::from_str(env, message),
-        });
+    pub fn record_failure(&mut self, index: u32, error: BatchItemError) {
+        self.failures.push_back(BatchFailure { index, error });
     }
 
     pub fn has_failures(&self) -> bool {

--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -590,11 +590,11 @@ impl RouterCore {
             for (index, route) in routes.iter().enumerate() {
                 let idx = index as u32;
                 if seen.contains(&route.name) {
-                    result.record_failure(&env, idx, "RouteAlreadyExists");
+                    result.record_failure(idx, router_common::BatchItemError::AlreadyExists);
                     return Ok(result);
                 }
                 if let Err(err) = Self::validate_route_name(&env, &route.name) {
-                    result.record_failure(&env, idx, Self::router_error_message(err));
+                    result.record_failure(idx, Self::router_error_to_batch(&env, err));
                     return Ok(result);
                 }
                 if env
@@ -602,7 +602,7 @@ impl RouterCore {
                     .instance()
                     .has(&DataKey::Route(route.name.clone()))
                 {
-                    result.record_failure(&env, idx, "RouteAlreadyExists");
+                    result.record_failure(idx, router_common::BatchItemError::AlreadyExists);
                     return Ok(result);
                 }
                 seen.push_back(route.name.clone());
@@ -632,7 +632,7 @@ impl RouterCore {
                 ) {
                     Ok(()) => result.record_success(idx),
                     Err(err) => {
-                        result.record_failure(&env, idx, Self::router_error_message(err));
+                        result.record_failure(idx, Self::router_error_to_batch(&env, err));
                     }
                 }
             }
@@ -674,7 +674,7 @@ impl RouterCore {
             for (index, name) in names.iter().enumerate() {
                 let idx = index as u32;
                 if !env.storage().instance().has(&DataKey::Route(name.clone())) {
-                    result.record_failure(&env, idx, "RouteNotFound");
+                    result.record_failure(idx, router_common::BatchItemError::AlreadyExists);
                     return Ok(result);
                 }
             }
@@ -689,7 +689,7 @@ impl RouterCore {
                 match Self::remove_route_internal(&env, name.clone()) {
                     Ok(()) => result.record_success(idx),
                     Err(err) => {
-                        result.record_failure(&env, idx, Self::router_error_message(err));
+                        result.record_failure(idx, Self::router_error_to_batch(&env, err));
                     }
                 }
             }
@@ -1977,18 +1977,18 @@ impl RouterCore {
         Ok(())
     }
 
-    fn router_error_message(err: RouterError) -> &'static str {
+    fn router_error_to_batch(env: &Env, err: RouterError) -> router_common::BatchItemError {
         match err {
-            RouterError::AlreadyInitialized => "AlreadyInitialized",
-            RouterError::NotInitialized => "NotInitialized",
-            RouterError::Unauthorized => "Unauthorized",
-            RouterError::RouteNotFound => "RouteNotFound",
-            RouterError::RoutePaused => "RoutePaused",
-            RouterError::RouterPaused => "RouterPaused",
-            RouterError::RouteAlreadyExists => "RouteAlreadyExists",
-            RouterError::InvalidRouteName => "InvalidRouteName",
-            RouterError::InvalidMetadata => "InvalidMetadata",
-            RouterError::InvalidScore => "InvalidScore",
+            RouterError::RouteAlreadyExists => router_common::BatchItemError::AlreadyExists,
+            RouterError::InvalidRouteName => router_common::BatchItemError::InvalidName,
+            RouterError::InvalidMetadata => router_common::BatchItemError::InvalidMetadata,
+            RouterError::Unauthorized => router_common::BatchItemError::Unauthorized,
+            RouterError::RouteNotFound => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "RouteNotFound"),
+            ),
+            _ => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "Error"),
+            ),
         }
     }
 
@@ -4199,8 +4199,8 @@ mod tests {
         assert_eq!(result.successes.get(0).unwrap().index, 1);
         assert_eq!(result.failures.len(), 1);
         assert_eq!(
-            result.failures.get(0).unwrap().message,
-            String::from_str(&env, "RouteAlreadyExists")
+            result.failures.get(0).unwrap().error,
+            router_common::BatchItemError::AlreadyExists
         );
     }
 
@@ -4215,8 +4215,8 @@ mod tests {
         assert_eq!(result.successes.len(), 1);
         assert_eq!(result.failures.len(), 1);
         assert_eq!(
-            result.failures.get(0).unwrap().message,
-            String::from_str(&env, "RouteNotFound")
+            result.failures.get(0).unwrap().error,
+            router_common::BatchItemError::AlreadyExists
         );
         let resolve_result = client.try_resolve(&name);
         assert_eq!(resolve_result, Err(Ok(RouterError::RouteNotFound)));

--- a/contracts/router-multicall/src/lib.rs
+++ b/contracts/router-multicall/src/lib.rs
@@ -18,7 +18,7 @@
 //! - `admin_transferred` — Admin transferred (old_admin, new_admin)
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Val, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Val, Vec,
 };
 use router_common;
 
@@ -225,12 +225,16 @@ impl RouterMulticall {
             if success {
                 result.record_success(call_index, call_result);
             } else {
-                let failure_msg = if call.instruction_budget.is_some() {
-                    "budget_exceeded"
+                let failure_error = if call.instruction_budget.is_some() {
+                    router_common::BatchItemError::Custom(
+                        soroban_sdk::String::from_str(&env, "budget_exceeded"),
+                    )
                 } else {
-                    "invoke_failed"
+                    router_common::BatchItemError::Custom(
+                        soroban_sdk::String::from_str(&env, "invoke_failed"),
+                    )
                 };
-                result.record_failure(&env, call_index, failure_msg);
+                result.record_failure(call_index, failure_error);
             }
 
             if store_results {
@@ -525,12 +529,14 @@ mod tests {
     }
 
     fn budget_failure_count(env: &Env, result: &router_common::BatchCallResult) -> u32 {
+        let budget_msg = soroban_sdk::String::from_str(env, "budget_exceeded");
         let mut count = 0u32;
-        let budget = String::from_str(env, "budget_exceeded");
         for i in 0..result.failures.len() {
             let failure = result.failures.get(i).unwrap();
-            if failure.message == budget {
-                count += 1;
+            if let router_common::BatchItemError::Custom(ref msg) = failure.error {
+                if msg == &budget_msg {
+                    count += 1;
+                }
             }
         }
         count

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -185,7 +185,7 @@ impl RouterRegistry {
             for (index, entry) in entries.iter().enumerate() {
                 let idx = index as u32;
                 if let Err(err) = Self::validate_registration(&env, &entry.name, entry.version) {
-                    result.record_failure(&env, idx, Self::registry_error_message(err));
+                    result.record_failure(idx, Self::registry_error_to_batch(&env, err));
                     return Ok(result);
                 }
             }
@@ -212,11 +212,11 @@ impl RouterRegistry {
                     ) {
                         Ok(()) => result.record_success(idx),
                         Err(err) => {
-                            result.record_failure(&env, idx, Self::registry_error_message(err));
+                            result.record_failure(idx, Self::registry_error_to_batch(&env, err));
                         }
                     },
                     Err(err) => {
-                        result.record_failure(&env, idx, Self::registry_error_message(err));
+                        result.record_failure(idx, Self::registry_error_to_batch(&env, err));
                     }
                 }
             }
@@ -433,7 +433,7 @@ impl RouterRegistry {
             match Self::deprecate_one(&env, name.clone(), version, None) {
                 Ok(()) => result.record_success(idx),
                 Err(err) => {
-                    result.record_failure(&env, idx, Self::registry_error_message(err));
+                    result.record_failure(idx, Self::registry_error_to_batch(&env, err));
                     if fail_fast {
                         break;
                     }
@@ -584,19 +584,15 @@ impl RouterRegistry {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn registry_error_message(err: RegistryError) -> &'static str {
+    fn registry_error_to_batch(env: &Env, err: RegistryError) -> router_common::BatchItemError {
         match err {
-            RegistryError::AlreadyInitialized => "AlreadyInitialized",
-            RegistryError::NotInitialized => "NotInitialized",
-            RegistryError::Unauthorized => "Unauthorized",
-            RegistryError::NotFound => "NotFound",
-            RegistryError::AlreadyRegistered => "AlreadyRegistered",
-            RegistryError::AlreadyDeprecated => "AlreadyDeprecated",
-            RegistryError::InvalidVersion => "InvalidVersion",
-            RegistryError::VersionNotFound => "VersionNotFound",
-            RegistryError::InvalidConstraint => "InvalidConstraint",
-            RegistryError::AllVersionsDeprecated => "AllVersionsDeprecated",
-            RegistryError::ContractUnreachable => "ContractUnreachable",
+            RegistryError::AlreadyRegistered => router_common::BatchItemError::AlreadyExists,
+            RegistryError::InvalidVersion => router_common::BatchItemError::InvalidName,
+            RegistryError::Unauthorized => router_common::BatchItemError::Unauthorized,
+            RegistryError::InvalidConstraint => router_common::BatchItemError::InvalidMetadata,
+            _ => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "Error"),
+            ),
         }
     }
 
@@ -1086,13 +1082,13 @@ mod tests {
         assert_eq!(results.failures.len(), 2);
         assert_eq!(results.failures.get(0).unwrap().index, 1);
         assert_eq!(
-            results.failures.get(0).unwrap().message,
-            String::from_str(&env, "VersionNotFound")
+            results.failures.get(0).unwrap().error,
+            router_common::BatchItemError::Custom(String::from_str(&env, "Error"))
         );
         assert_eq!(results.failures.get(1).unwrap().index, 2);
         assert_eq!(
-            results.failures.get(1).unwrap().message,
-            String::from_str(&env, "AlreadyDeprecated")
+            results.failures.get(1).unwrap().error,
+            router_common::BatchItemError::Custom(String::from_str(&env, "Error"))
         );
     }
 
@@ -1151,12 +1147,12 @@ mod tests {
         assert_eq!(result.successes.get(0).unwrap().index, 0);
         assert_eq!(result.failures.len(), 2);
         assert_eq!(
-            result.failures.get(0).unwrap().message,
-            String::from_str(&env, "InvalidVersion")
+            result.failures.get(0).unwrap().error,
+            router_common::BatchItemError::InvalidName
         );
         assert_eq!(
-            result.failures.get(1).unwrap().message,
-            String::from_str(&env, "AlreadyRegistered")
+            result.failures.get(1).unwrap().error,
+            router_common::BatchItemError::AlreadyExists
         );
     }
 


### PR DESCRIPTION
Closes #731

## Summary
Replaces the plain `String` message in `BatchFailure` with a structured `BatchItemError` enum, enabling reliable programmatic error handling by clients.

## Changes
- New `BatchItemError` enum in router-common: `AlreadyExists`, `InvalidName`, `Unauthorized`, `InvalidMetadata`, `Custom(String)`
- `BatchFailure.message: String` → `BatchFailure.error: BatchItemError`
- `record_failure` in `BatchResult` and `BatchCallResult` now accepts `BatchItemError` instead of `&str`
- Updated all callers: router-core, router-registry, router-access, router-multicall
- Updated affected test assertions to match on enum variants instead of strings