### PR TITLE
ci: add cargo-deny license and advisory audit to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,18 @@ jobs:
       - name: Validate dependency graph
         run: bash scripts/validate-dependencies.sh
 
+  dependency-audit:
+    name: Dependency Audit (cargo-deny)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Audit dependencies
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories licenses bans
+
   build:
     name: Build WASM
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves #730

Adds a `dependency-audit` job to `.github/workflows/ci.yml` that enforces the existing `deny.toml` configuration as part of the CI pipeline.

## Changes

`.github/workflows/ci.yml` — new `dependency-audit` job:
- Uses the official `EmbarkStudios/cargo-deny-action@v2` action
- Runs `cargo deny check advisories licenses bans`
- Depends on the `test` job (runs in parallel with `build`, `coverage`, etc.)
- No additional configuration needed — uses the repo's existing `deny.toml`

## What cargo-deny checks
| Check | Effect |
|---|---|
| `advisories` | Blocks merging dependencies with known RustSec CVEs |
| `licenses` | Enforces the allow/deny license list in `deny.toml` |
| `bans` | Detects banned or duplicate crates per `deny.toml` |

## Why this approach
The `EmbarkStudios/cargo-deny-action` caches the `cargo-deny` binary, making it faster than `cargo install --locked cargo-deny` on each run. It is the official, actively-maintained action recommended by the cargo-deny project.

## Impact
- Vulnerable dependencies are now caught at PR time
- License violations surface before merge
- Zero additional pipeline time — job runs in parallel with other post-test jobs