### PR TITLE
fix(api-server): repair build-breaking merge artifacts, wire ConnectI…

### DIFF
--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -148,9 +148,6 @@ pub async fn get_route(
                 ErrorCode::NotFound,
                 format!("route '{}' not found", name),
             )),
-            Json(ErrorResponse {
-                error: format!("route '{}' not found", name),
-            }),
         )),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -121,6 +121,7 @@ async fn main() -> Result<()> {
         max_requests: args.rate_limit_max_requests,
         window: std::time::Duration::from_secs(args.rate_limit_window_secs),
     });
+    rate_limiter.spawn_sweeper();
 
     let state = AppState::new(
         args.rpc_url,
@@ -160,7 +161,11 @@ async fn main() -> Result<()> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
 
     let drain_timeout = std::time::Duration::from_secs(args.shutdown_timeout_secs);
-    let serve = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
+    let serve = axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal());
 
     match tokio::time::timeout(drain_timeout, serve).await {
         Ok(result) => result?,

--- a/api-server/src/rate_limit.rs
+++ b/api-server/src/rate_limit.rs
@@ -1,7 +1,10 @@
 //! Simple per-client rate limiting middleware for the API server.
 //!
-//! Tracks requests by `X-Api-Key` header or remote IP and rejects excess
-//! requests with HTTP 429.
+//! Tracks requests by remote IP address and rejects excess requests with
+//! HTTP 429. The client cannot influence its own bucket key: an
+//! unauthenticated, client-supplied override (e.g. a header) would let an
+//! attacker pick a fresh key per request and dodge the limit entirely, and
+//! would also let them grow `buckets` without bound.
 
 use std::{net::SocketAddr, sync::Arc, time::{Duration, Instant}};
 
@@ -93,6 +96,22 @@ impl RateLimiter {
         }
         1
     }
+
+    /// Spawns a background task that periodically evicts buckets whose window
+    /// has expired, so `buckets` cannot grow without bound over the life of
+    /// the process. Must be called from within a Tokio runtime.
+    pub fn spawn_sweeper(&self) {
+        let buckets = self.buckets.clone();
+        let window = self.config.window;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(window);
+            loop {
+                interval.tick().await;
+                let now = Instant::now();
+                buckets.retain(|_, entry| now.duration_since(entry.window_start) < window);
+            }
+        });
+    }
 }
 
 #[derive(Serialize)]
@@ -113,12 +132,7 @@ pub async fn rate_limit_middleware(
         .map(|connect_info| connect_info.0)
         .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 0)));
 
-    let key = req
-        .headers()
-        .get("x-api-key")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| remote_addr.ip().to_string());
+    let key = remote_addr.ip().to_string();
 
     let limiter = &state.rate_limiter;
     let allowed = limiter.check(&key);

--- a/api-server/src/tests.rs
+++ b/api-server/src/tests.rs
@@ -33,9 +33,69 @@ fn test_app() -> Router {
     Router::new()
         .route("/simulate", post(handlers::simulate))
         .route("/health", get(handlers::health))
+        .route("/routes", get(handlers::list_routes))
         .route("/routes/:name", get(handlers::get_route))
         .layer(middleware::from_fn(crate::rate_limit::rate_limit_middleware))
         .with_state(state)
+}
+
+/// Like `test_app`, but with a non-empty `router_core_contract_id` so
+/// `list_routes` takes the RPC-call path instead of the 503 short-circuit.
+fn test_app_with_core_contract() -> Router {
+    let rate_limiter = RateLimiter::new(RateLimitConfig::default());
+    let state = AppState::new(
+        "http://localhost:1".to_string(),
+        "".to_string(),
+        VALID_CONTRACT_ID.to_string(),
+        rate_limiter,
+        10,
+    );
+
+    Router::new()
+        .route("/routes", get(handlers::list_routes))
+        .layer(middleware::from_fn(crate::rate_limit::rate_limit_middleware))
+        .with_state(state)
+}
+
+#[tokio::test]
+async fn test_list_routes_returns_503_when_core_not_configured() {
+    let app = test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/routes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json["error"]["code"].is_string());
+    assert!(json["error"]["message"].is_string());
+}
+
+#[tokio::test]
+async fn test_list_routes_returns_500_on_rpc_error() {
+    let app = test_app_with_core_contract();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/routes")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["error"]["code"].as_str().unwrap(), "RPC_ERROR");
 }
 
 #[tokio::test]

--- a/api-server/src/websocket.rs
+++ b/api-server/src/websocket.rs
@@ -39,11 +39,6 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
 
     info!("WebSocket client connected");
 
-    let mut subscriptions: Vec<String> = Vec::new();
-    let mut rx_handles: Vec<(
-        String,
-        tokio::sync::broadcast::Receiver<TransactionStatusEvent>,
-    )> = Vec::new();
     let mut last_activity = tokio::time::Instant::now();
     let mut ping_ticker = tokio::time::interval(PING_INTERVAL);
     ping_ticker.tick().await; // consume the immediate first tick
@@ -76,13 +71,8 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                                         }
                                     } else {
                                         info!("Client subscribed to tx_id: {}", sub_msg.tx_id);
-                                        subscriptions.push(sub_msg.tx_id.clone());
+                                        subscriptions.insert(sub_msg.tx_id.clone());
                                         state.add_subscriber(sub_msg.tx_id.clone());
-                                        let rx = state.tx_status_tx.subscribe();
-                                        rx_handles.push((sub_msg.tx_id.clone(), rx));
-                                    info!("Client subscribed to tx_id: {}", sub_msg.tx_id);
-                                    subscriptions.insert(sub_msg.tx_id.clone());
-                                    state.add_subscriber(sub_msg.tx_id.clone());
 
                                         let response = json!({
                                             "msg_type": "subscribed",


### PR DESCRIPTION
…nfo, close rate-limit bypass

- websocket.rs: remove leftover Vec/rx_handles declarations and duplicate subscribe block left from a merge; keep only the HashSet-based path that pairs with recv_matching (#838)
- handlers.rs: remove a matching leftover duplicate Json(ErrorResponse) in get_route's not-found arm that also broke compilation
- main.rs: serve via into_make_service_with_connect_info so rate_limit_middleware actually receives ConnectInfo<SocketAddr> instead of always falling back to 127.0.0.1 (#839)
- rate_limit.rs: drop the client-controlled X-Api-Key override (an attacker could pick a fresh key per request and dodge the limit entirely); key strictly by connection IP. Add spawn_sweeper() to evict expired buckets so the map can't grow unbounded (#840)
- tests.rs: mount GET /routes in the test harness and cover the 503-not-configured and RPC-error paths for list_routes (#841)

Fixes #838, #839, #840, #841

closes #838, closes #839, closes #840, closes #841