### PR TITLE
fix(ci): add api-server CI coverage, scan all workspaces for audits, …

### DIFF
--- a/.github/workflows/api-server.yml
+++ b/.github/workflows/api-server.yml
@@ -1,0 +1,102 @@
+name: API Server CI
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'api-server/**'
+      - '.github/workflows/api-server.yml'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'api-server/**'
+      - '.github/workflows/api-server.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: api-server/target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('api-server/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test --manifest-path api-server/Cargo.toml --verbose
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path api-server/Cargo.toml -- --check
+
+      - name: Run clippy
+        run: cargo clippy --manifest-path api-server/Cargo.toml -- -D warnings
+
+  build:
+    name: Build Binary
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --manifest-path api-server/Cargo.toml --target ${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: router-api-server-${{ matrix.target }}
+          path: api-server/target/${{ matrix.target }}/release/router-api-server*
+
+  docker:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test, build]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: api-server/Dockerfile
+          push: false
+          tags: stellar-router/api-server:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
     name: Dependency Audit (cargo-deny)
     runs-on: ubuntu-latest
     needs: test
+    strategy:
+      matrix:
+        manifest: [Cargo.toml, metrics/Cargo.toml, api-server/Cargo.toml]
     steps:
       - uses: actions/checkout@v4
 
@@ -97,6 +100,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories licenses bans
+          manifest-path: ${{ matrix.manifest }}
 
   build:
     name: Build WASM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,8 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
       - name: Build WASM artifacts
-        run: wasm-pack build --target web --out-dir pkg
+        run: cargo build --target wasm32-unknown-unknown --release
 
       - name: Generate changelog from conventional commits
         id: changelog
@@ -46,8 +43,6 @@ jobs:
           name: Release ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.content }}
           files: |
-            pkg/*.wasm
-            pkg/*.js
-            pkg/*.ts
+            target/wasm32-unknown-unknown/release/*.wasm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,6 +9,9 @@ jobs:
   audit:
     name: Cargo Audit & Deny
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        manifest: [Cargo.toml, metrics/Cargo.toml, api-server/Cargo.toml]
     steps:
       - uses: actions/checkout@v4
 
@@ -31,7 +34,7 @@ jobs:
         run: cargo install cargo-deny
 
       - name: Run cargo audit
-        run: cargo audit
+        run: cargo audit --file $(dirname ${{ matrix.manifest }})/Cargo.lock
 
       - name: Run cargo deny
-        run: cargo deny check
+        run: cargo deny check --manifest-path ${{ matrix.manifest }}

--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -2,6 +2,12 @@
 # ── Build stage ───────────────────────────────────────────────────────────────
 FROM rust:1.88-slim AS builder
 
+# curl is required by utoipa-swagger-ui's build script, which downloads the
+# Swagger UI release archive at compile time.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy dependency files first for better layer caching

--- a/api-server/src/handlers.rs
+++ b/api-server/src/handlers.rs
@@ -4,15 +4,13 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use serde_json::json;
 use tracing::{error, info};
-use utoipa::ToSchema;
 
 use crate::{
     state::AppState,
     types::{
-        ErrorCode, ErrorResponse, FeeEstimate, HealthResponse, RouteListResponse, RouteEntryResponse,
-        SimulateRequest, SimulateResponse, SimulationDetail,
+        ErrorCode, ErrorResponse, FeeEstimate, HealthResponse, RouteEntryResponse,
+        RouteListResponse, SimulateRequest, SimulateResponse, SimulationDetail,
     },
 };
 
@@ -146,7 +144,7 @@ pub async fn get_route(
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::new(
                 ErrorCode::NotFound,
-                format!("route '{}' not found", name),
+                format!("route '{name}' not found"),
             )),
         )),
         Err(e) => Err((

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -22,11 +22,13 @@ use std::net::SocketAddr;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{info, info_span, warn, Instrument};
 
-
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::{rate_limit::{RateLimitConfig, RateLimiter}, state::AppState};
+use crate::{
+    rate_limit::{RateLimitConfig, RateLimiter},
+    state::AppState,
+};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -99,9 +101,6 @@ struct Args {
     rpc_timeout_secs: u64,
 }
 
-
-
-
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -131,8 +130,6 @@ async fn main() -> Result<()> {
         args.rpc_timeout_secs,
     );
 
-
-
     let cors = build_cors_layer(&args.cors_origins);
 
     let docs = SwaggerUi::new("/docs/{tail:.*}").url("/openapi.json", ApiDoc::openapi());
@@ -145,7 +142,10 @@ async fn main() -> Result<()> {
         .route("/ws", get(websocket::ws_handler))
         .route("/openapi.json", get(openapi_json))
         .merge(docs)
-        .layer(middleware::from_fn(rate_limit::rate_limit_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            rate_limit::rate_limit_middleware,
+        ))
         .layer(middleware::from_fn(request_id_middleware))
         .layer(cors)
         .layer(DefaultBodyLimit::max(1024 * 1024))

--- a/api-server/src/rate_limit.rs
+++ b/api-server/src/rate_limit.rs
@@ -6,7 +6,11 @@
 //! attacker pick a fresh key per request and dodge the limit entirely, and
 //! would also let them grow `buckets` without bound.
 
-use std::{net::SocketAddr, sync::Arc, time::{Duration, Instant}};
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use axum::{
     body::Body,
@@ -123,8 +127,8 @@ struct RateLimitError {
 
 pub async fn rate_limit_middleware(
     State(state): State<crate::state::AppState>,
-    mut req: Request<Body>,
-    next: Next<Body>,
+    req: Request<Body>,
+    next: Next,
 ) -> Response {
     let remote_addr = req
         .extensions()
@@ -163,10 +167,7 @@ pub async fn rate_limit_middleware(
             )],
             Json(RateLimitError {
                 error: "rate_limit_exceeded",
-                message: format!(
-                    "Too many requests. Retry after {} second(s).",
-                    retry_after
-                ),
+                message: format!("Too many requests. Retry after {retry_after} second(s)."),
                 retry_after_secs: retry_after,
             }),
         )

--- a/api-server/src/rpc.rs
+++ b/api-server/src/rpc.rs
@@ -68,14 +68,11 @@ pub struct FeeBreakdown {
     pub fee_estimated: bool,
     /// `true` only when fees were derived from a live RPC simulation.
     /// `false` when the heuristic fallback was used (RPC unreachable).
+    #[allow(dead_code)]
     pub simulated: bool,
 }
 
 impl SorobanRpcClient {
-    pub fn new(rpc_url: impl Into<String>, router_core_contract_id: Option<String>) -> Self {
-        Self::with_timeout(rpc_url, router_core_contract_id, 10)
-    }
-
     pub fn with_timeout(
         rpc_url: impl Into<String>,
         router_core_contract_id: Option<String>,
@@ -95,7 +92,6 @@ impl SorobanRpcClient {
         }
     }
 
-
     /// Ping the RPC node via `getLatestLedger`. Returns `Ok(())` if reachable.
     pub async fn health_check(&self) -> Result<()> {
         let req = JsonRpcRequest {
@@ -110,7 +106,7 @@ impl SorobanRpcClient {
             .json(&req)
             .send()
             .await
-            .map_err(|e| anyhow!("RPC unreachable: {}", e))?;
+            .map_err(|e| anyhow!("RPC unreachable: {e}"))?;
         if !resp.status().is_success() {
             return Err(anyhow!("RPC returned status {}", resp.status()));
         }
@@ -160,7 +156,7 @@ impl SorobanRpcClient {
     }
 
     pub async fn get_all_routes(&self, contract_id: &str) -> Result<Vec<String>> {
-        let placeholder_xdr = format!("AAAAAgAAAAEAAAAA{}get_all_routesAAAAAAAAAAAA=", contract_id);
+        let placeholder_xdr = format!("AAAAAgAAAAEAAAAA{contract_id}get_all_routesAAAAAAAAAAAA=");
 
         let req = JsonRpcRequest {
             jsonrpc: "2.0",
@@ -175,10 +171,10 @@ impl SorobanRpcClient {
             .json(&req)
             .send()
             .await
-            .map_err(|e| anyhow!("RPC request failed: {}", e))?
+            .map_err(|e| anyhow!("RPC request failed: {e}"))?
             .json()
             .await
-            .map_err(|e| anyhow!("Failed to parse RPC response: {}", e))?;
+            .map_err(|e| anyhow!("Failed to parse RPC response: {e}"))?;
 
         if let Some(err) = resp.error {
             return Err(anyhow!("RPC error: {}", err.message));
@@ -187,7 +183,7 @@ impl SorobanRpcClient {
         let result = resp.result.ok_or_else(|| anyhow!("empty RPC result"))?;
 
         if let Some(err) = result.error {
-            return Err(anyhow!("contract error: {}", err));
+            return Err(anyhow!("contract error: {err}"));
         }
 
         let routes = result
@@ -206,7 +202,7 @@ impl SorobanRpcClient {
             .as_deref()
             .ok_or_else(|| anyhow!("ROUTER_CORE_CONTRACT_ID not configured"))?;
 
-        let placeholder_xdr = format!("get_route:{}:{}", contract_id, name);
+        let placeholder_xdr = format!("get_route:{contract_id}:{name}");
 
         let req = JsonRpcRequest {
             jsonrpc: "2.0",
@@ -369,7 +365,7 @@ impl SorobanRpcClient {
         target: &str,
         function: &str,
     ) -> Result<SimulateTransactionResult> {
-        let placeholder_xdr = format!("AAAAAgAAAAEAAAAA{}{}AAAAAAAAAAA=", target, function);
+        let placeholder_xdr = format!("AAAAAgAAAAEAAAAA{target}{function}AAAAAAAAAAA=");
         let req = JsonRpcRequest {
             jsonrpc: "2.0",
             id: 1,

--- a/api-server/src/state.rs
+++ b/api-server/src/state.rs
@@ -33,7 +33,11 @@ impl AppState {
     ) -> Self {
         let (tx_status_tx, _) = broadcast::channel(1000);
         Self {
-            rpc: SorobanRpcClient::with_timeout(rpc_url, Some(router_core_contract_id.clone()), rpc_timeout_secs),
+            rpc: SorobanRpcClient::with_timeout(
+                rpc_url,
+                Some(router_core_contract_id.clone()),
+                rpc_timeout_secs,
+            ),
 
             execution_contract_id,
             router_core_contract_id,

--- a/api-server/src/tests.rs
+++ b/api-server/src/tests.rs
@@ -35,7 +35,10 @@ fn test_app() -> Router {
         .route("/health", get(handlers::health))
         .route("/routes", get(handlers::list_routes))
         .route("/routes/:name", get(handlers::get_route))
-        .layer(middleware::from_fn(crate::rate_limit::rate_limit_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            crate::rate_limit::rate_limit_middleware,
+        ))
         .with_state(state)
 }
 
@@ -53,7 +56,10 @@ fn test_app_with_core_contract() -> Router {
 
     Router::new()
         .route("/routes", get(handlers::list_routes))
-        .layer(middleware::from_fn(crate::rate_limit::rate_limit_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            crate::rate_limit::rate_limit_middleware,
+        ))
         .with_state(state)
 }
 
@@ -196,20 +202,12 @@ async fn test_simulate_rate_limit_headers_and_rejects_after_limit() {
     };
 
     for _ in 0..100 {
-        let resp = app
-            .clone()
-            .oneshot(request())
-            .await
-            .unwrap();
+        let resp = app.clone().oneshot(request()).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.headers()["x-rate-limit-limit"], "100");
     }
 
-    let resp = app
-        .clone()
-        .oneshot(request())
-        .await
-        .unwrap();
+    let resp = app.clone().oneshot(request()).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
     assert!(resp.headers().get("retry-after").is_some());
@@ -656,7 +654,10 @@ fn test_valid_subscribe_message_parses_correctly() {
 fn test_malformed_json_returns_parse_error() {
     let bad_json = "not valid json {{{{";
     let result: Result<crate::types::SubscribeMessage, _> = serde_json::from_str(bad_json);
-    assert!(result.is_err(), "malformed JSON must not parse successfully");
+    assert!(
+        result.is_err(),
+        "malformed JSON must not parse successfully"
+    );
 }
 
 /// An object that is valid JSON but missing required fields must also fail.
@@ -753,9 +754,7 @@ fn test_broadcast_channel_has_adequate_capacity() {
     // and that the channel is functional after creation.
     let state = ws_app_state();
     // Subscribing up to a representative number of simultaneous connections must not panic.
-    let _receivers: Vec<_> = (0..100)
-        .map(|_| state.tx_status_tx.subscribe())
-        .collect();
+    let _receivers: Vec<_> = (0..100).map(|_| state.tx_status_tx.subscribe()).collect();
     // All 100 subscriptions succeeded without panic — channel capacity is adequate.
 }
 

--- a/api-server/src/types.rs
+++ b/api-server/src/types.rs
@@ -164,7 +164,7 @@ pub struct TransactionStatusEvent {
     pub message: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum TransactionStatus {
     Pending,

--- a/api-server/src/websocket.rs
+++ b/api-server/src/websocket.rs
@@ -7,8 +7,8 @@ use axum::{
 };
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
-use std::time::Duration;
 use std::collections::HashSet;
+use std::time::Duration;
 use tracing::{error, info, warn};
 
 use crate::{
@@ -42,8 +42,8 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     let mut last_activity = tokio::time::Instant::now();
     let mut ping_ticker = tokio::time::interval(PING_INTERVAL);
     ping_ticker.tick().await; // consume the immediate first tick
-    // One receiver for the whole connection. Events for all subscriptions
-    // arrive on the same broadcast channel and are filtered by tx_id below.
+                              // One receiver for the whole connection. Events for all subscriptions
+                              // arrive on the same broadcast channel and are filtered by tx_id below.
     let mut rx = state.tx_status_tx.subscribe();
     let mut subscriptions: HashSet<String> = HashSet::new();
 

--- a/metrics/src/collector.rs
+++ b/metrics/src/collector.rs
@@ -412,7 +412,7 @@ impl Collector {
 /// Produces a string key that the mock client can match on. In production
 /// this should be replaced with proper XDR encoding via the `stellar-xdr` crate.
 fn encode_contract_data_key(contract_id: &str, storage_key: &str) -> String {
-    format!("{}:{}", contract_id, storage_key)
+    format!("{contract_id}:{storage_key}")
 }
 
 /// Extract a `u64` value from a `getLedgerEntries` response for the given key name.

--- a/metrics/src/rate_limit.rs
+++ b/metrics/src/rate_limit.rs
@@ -132,7 +132,7 @@ pub async fn rate_limit_middleware(
             [("retry-after", retry_after.to_string())],
             Json(RateLimitError {
                 error: "rate_limit_exceeded",
-                message: format!("Too many requests. Retry after {} second(s).", retry_after),
+                message: format!("Too many requests. Retry after {retry_after} second(s)."),
                 retry_after_secs: retry_after,
             }),
         )

--- a/metrics/src/replay_protection.rs
+++ b/metrics/src/replay_protection.rs
@@ -15,6 +15,7 @@ use axum::{
 };
 use dashmap::DashMap;
 use std::env;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
@@ -66,6 +67,7 @@ struct NonceEntry {
 pub struct NonceCache {
     cache: Arc<DashMap<String, NonceEntry>>,
     config: ReplayProtectionConfig,
+    last_swept_at: Arc<AtomicU64>,
 }
 
 impl NonceCache {
@@ -74,6 +76,7 @@ impl NonceCache {
         NonceCache {
             cache: Arc::new(DashMap::new()),
             config,
+            last_swept_at: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -82,8 +85,10 @@ impl NonceCache {
     pub fn check_and_add(&self, nonce: &str) -> bool {
         let now = current_timestamp();
 
-        // Clean up expired nonces
-        self.cleanup_expired(now);
+        // Full-table cleanup is O(n); only run it at most once per sweep
+        // interval instead of on every request, otherwise every request on
+        // the hot path pays for a full DashMap scan/lock of every shard.
+        self.maybe_cleanup_expired(now);
 
         // Check if nonce already exists
         if self.cache.contains_key(nonce) {
@@ -102,6 +107,24 @@ impl NonceCache {
             .insert(nonce.to_string(), NonceEntry { timestamp: now });
 
         true
+    }
+
+    /// Run `cleanup_expired` only if at least one sweep interval has passed
+    /// since the last sweep, so concurrent requests don't each pay for a
+    /// full-table scan when nothing has expired yet.
+    fn maybe_cleanup_expired(&self, now: u64) {
+        let sweep_interval = (self.config.nonce_ttl_secs / 10).max(1);
+        let last = self.last_swept_at.load(Ordering::Relaxed);
+        if now.saturating_sub(last) < sweep_interval {
+            return;
+        }
+        if self
+            .last_swept_at
+            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            self.cleanup_expired(now);
+        }
     }
 
     /// Clean up expired nonces from the cache.

--- a/metrics/src/rpc.rs
+++ b/metrics/src/rpc.rs
@@ -520,6 +520,7 @@ impl MockRpcClient {
         self
     }
 
+    #[allow(dead_code)]
     pub fn with_bool(mut self, contract: &str, func: &str, val: bool) -> Self {
         self.bool_responses
             .insert((contract.to_string(), func.to_string()), val);


### PR DESCRIPTION
…fix release wasm build, rate-limit nonce cleanup

- closes #837: add api-server.yml CI workflow (fmt, clippy, test, build, docker)
- closes #836: matrix cargo-audit/cargo-deny over root, metrics/, api-server/ manifests
- closes #834: replace broken wasm-pack step in release.yml with cargo build --target wasm32-unknown-unknown
- closes #833: rate-limit NonceCache::cleanup_expired to once per sweep interval instead of every request

Also fixes pre-existing breakage uncovered while validating the above: api-server didn't compile (axum 0.7 Next<Body>/from_fn_with_state mismatch, missing ToSchema derive), ~20 clippy -D warnings violations across both crates, and a missing curl dependency in api-server/Dockerfile's builder stage needed by utoipa-swagger-ui's build script.