### PR TITLE
fix(router-access, router-timelock): close blacklist bypass, stale bookkeeping, and timelock dependency/replay gaps

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -120,12 +120,30 @@ impl RouterAccess {
             return Err(AccessError::RoleNotFound);
         }
 
+        Self::deactivate_role_grant(&env, &role, &target);
+
+        env.events().publish(
+            (Symbol::new(&env, router_common::EVENT_ROLE_REVOKED),),
+            (role, target),
+        );
+        Ok(())
+    }
+
+    /// Shared bookkeeping for deactivating a role grant: removes the
+    /// `HasRole` entry, decrements `RoleMemberCount` when the grant was
+    /// active, and removes `target`/`role` from the `RoleMembers` /
+    /// `AddressRoles` index vectors. Used by both `revoke_role` and
+    /// `expire_role` so storage stays consistent regardless of which path
+    /// deactivated the grant.
+    fn deactivate_role_grant(env: &Env, role: &String, target: &Address) {
         // Decrement active-member counter only if this grant was currently active.
         // (If the role is expired, it may still exist in HasRole but shouldn't be
         // counted as an active member.)
-        let was_active = Self::has_role_internal(&env, &target, &role);
+        let was_active = Self::has_role_internal(env, target, role);
 
-        env.storage().instance().remove(&key);
+        env.storage()
+            .instance()
+            .remove(&DataKey::HasRole(role.clone(), target.clone()));
 
         if was_active {
             let current: u32 = env
@@ -143,8 +161,8 @@ impl RouterAccess {
             .storage()
             .instance()
             .get(&DataKey::RoleMembers(role.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
-        if let Some(i) = members.iter().position(|a| a == target) {
+            .unwrap_or_else(|| Vec::new(env));
+        if let Some(i) = members.iter().position(|a| a == *target) {
             members.remove(i as u32);
         }
         env.storage()
@@ -155,8 +173,8 @@ impl RouterAccess {
             .storage()
             .instance()
             .get(&DataKey::AddressRoles(target.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
-        if let Some(i) = roles.iter().position(|r| r == role) {
+            .unwrap_or_else(|| Vec::new(env));
+        if let Some(i) = roles.iter().position(|r| r == *role) {
             roles.remove(i as u32);
         }
         env.storage()
@@ -168,7 +186,7 @@ impl RouterAccess {
             .remove(&DataKey::RoleExpiry(role.clone(), target.clone()));
 
         // Keep RoleMemberCount consistent for expiry-based removal.
-        if Self::has_role_internal(&env, &target, &role) {
+        if Self::has_role_internal(env, target, role) {
             let current: u32 = env
                 .storage()
                 .instance()
@@ -179,12 +197,6 @@ impl RouterAccess {
                 .instance()
                 .set(&DataKey::RoleMemberCount(role.clone()), &new_count);
         }
-
-        env.events().publish(
-            (Symbol::new(&env, router_common::EVENT_ROLE_REVOKED),),
-            (role, target),
-        );
-        Ok(())
     }
 
     /// Check if an address has a role (and it has not expired).
@@ -545,6 +557,9 @@ impl RouterAccess {
     ) -> Result<(), AccessError> {
         current.require_auth();
         Self::require_super_admin(&env, &current)?;
+        if Self::is_blacklisted_internal(&env, &new_admin) {
+            return Err(AccessError::Blacklisted);
+        }
         env.storage()
             .instance()
             .set(&DataKey::SuperAdmin, &new_admin);
@@ -570,12 +585,7 @@ impl RouterAccess {
     ) -> Result<(), AccessError> {
         caller.require_auth();
         Self::require_super_admin(&env, &caller)?;
-        env.storage()
-            .instance()
-            .remove(&DataKey::RoleExpiry(role.clone(), target.clone()));
-        env.storage()
-            .instance()
-            .remove(&DataKey::HasRole(role.clone(), target.clone()));
+        Self::deactivate_role_grant(&env, &role, &target);
         env.events().publish(
             (Symbol::new(&env, router_common::EVENT_ROLE_EXPIRED),),
             (role, target),
@@ -714,6 +724,9 @@ impl RouterAccess {
     }
 
     fn require_super_admin(env: &Env, caller: &Address) -> Result<(), AccessError> {
+        if Self::is_blacklisted_internal(env, caller) {
+            return Err(AccessError::Blacklisted);
+        }
         let admin: Address = env
             .storage()
             .instance()

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -83,6 +83,10 @@ pub enum TimelockError {
     CircularDependency = 11,
     /// Dependency chain exceeds maximum allowed depth.
     DependencyTooDeep = 12,
+    /// An operation with this op_id has already been queued.
+    AlreadyQueued = 13,
+    /// One or more of this operation's dependencies has not yet been executed.
+    DependencyNotExecuted = 14,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -165,6 +169,10 @@ impl RouterTimelock {
         preimage.append(&Bytes::from_array(&env, &eta_bytes));
 
         let op_id: Bytes = env.crypto().sha256(&preimage).into();
+
+        if env.storage().instance().has(&DataKey::Op(op_id.clone())) {
+            return Err(TimelockError::AlreadyQueued);
+        }
 
         // Validate no circular dependencies
         for dep_id in deps.iter() {
@@ -260,6 +268,22 @@ impl RouterTimelock {
         }
         if now > op.eta + op.grace_period_seconds {
             return Err(TimelockError::Expired);
+        }
+
+        let deps: Vec<Bytes> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Deps(op_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        for dep_id in deps.iter() {
+            let dep_op: Op = env
+                .storage()
+                .instance()
+                .get(&DataKey::Op(dep_id))
+                .ok_or(TimelockError::DependencyNotExecuted)?;
+            if !dep_op.executed {
+                return Err(TimelockError::DependencyNotExecuted);
+            }
         }
 
         op.executed = true;


### PR DESCRIPTION
## Summary

Fixes four bugs across `router-access` and `router-timelock`:

- **#819** — `require_super_admin()` never checked blacklist status, so the sequence transfer→blacklist→transfer-back let a blacklisted address regain super-admin authority. It now rejects blacklisted callers, and `transfer_super_admin()` also rejects handing authority to a blacklisted `new_admin`.
- **#820** — `expire_role()` only removed `RoleExpiry`/`HasRole`, leaving `RoleMemberCount`, `RoleMembers`, and `AddressRoles` stale (unlike `revoke_role()`). Extracted the shared bookkeeping into a `deactivate_role_grant()` helper used by both.
- **#821** — `execute()` never checked an operation's `deps`, so dependency ordering was write-only metadata with no enforcement. It now requires every declared dependency's `Op` to exist and be `executed` before allowing execution (new `TimelockError::DependencyNotExecuted`).
- **#822** — `queue()` had no collision guard on `op_id`, so re-queuing the same `(description, target, eta)` triple could silently reset an already-executed/cancelled operation back to pending. It now rejects a colliding `op_id` (new `TimelockError::AlreadyQueued`).

## Test plan
- [ ] Not run in this PR per requester's instructions — please run the existing `router-access`/`router-timelock` test suites plus the regression cases described in each issue before merging.

Closes #819, 
Closes #820, 
Closes #821,
Closes #822.