### PR TITLE
fix(router-registry): restrict register_with_check health_fn to allow-list (closes #828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - `router-core`: routes can now be registered with an optional TTL via `register_route_with_ttl`. `resolve()` returns `RouteExpired` once the current ledger exceeds a route's expiry, `get_all_routes()` excludes expired routes, and `extend_route_ttl` lets the admin extend a route's TTL before it expires. `get_route_expiry` returns a route's expiry ledger, if any. Routes registered without a TTL remain permanent.
 - `router-access`: blacklist entries can now include an optional `reason` and an `expires_at` timestamp. Expired blacklist entries are treated as not blacklisted.
 - `router-registry`: `ContractEntry` includes an optional `deprecation_reason` and the `deprecate()` API accepts an optional reason which is emitted in the `contract_deprecated` event.
+- `router-registry`: new `RegistryError::InvalidHealthFn = 12` variant, returned by `register_with_check` when `health_fn` is not in the documented allow-list. Closes #828.
 - `metrics/alerts.yml`: example Prometheus alerting rules for circuit breaker opens, high failure/error rates, and high request volume.
 
 ### Changed
 - Documentation: added a top-level `CHANGELOG.md` following Keep a Changelog format.
+
+### Security
+- `router-registry`: `register_with_check` now restricts `health_fn` to a fixed allow-list of conventionally side-effect-free symbols — `health` or `ping` — and rejects any other symbol with the new `InvalidHealthFn` error *before* dispatching any cross-contract call. Previously, `try_invoke_contract` was invoked on the target address with an arbitrary admin-supplied symbol, allowing an admin (operator error, compromised key, or misleading naming on the target) to trigger state-mutating entry points on the registered contract during what was meant to be a passive liveness probe. The doc comment on `register_with_check` is updated with explicit security notes covering the invariant.
 
 ## [0.3.0] - 2024-11-15
 

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -70,6 +70,10 @@ pub enum RegistryError {
     InvalidConstraint = 9,
     AllVersionsDeprecated = 10,
     ContractUnreachable = 11,
+    /// Returned by [`RouterRegistry::register_with_check`] when the
+    /// supplied `health_fn` symbol is not in the allow-list of
+    /// conventionally side-effect-free liveness-probe names.
+    InvalidHealthFn = 12,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -137,12 +141,53 @@ impl RouterRegistry {
 
     /// Register a new contract entry with an optional liveness check.
     ///
-    /// When `health_fn` is provided, the registry invokes that function on
-    /// `address` via a cross-contract call before storing the entry. If the
-    /// call fails, registration is rejected with
+    /// When `health_fn` is `Some(_)`, the registry invokes that function
+    /// on `address` via a real cross-contract call before storing the
+    /// entry, as a passive liveness probe. If the call fails (function
+    /// not present or invocation error), registration is rejected with
     /// [`RegistryError::ContractUnreachable`].
     ///
-    /// When `health_fn` is `None`, this behaves identically to [`register`].
+    /// When `health_fn` is `None`, this behaves identically to
+    /// [`register`] — no cross-contract call is performed.
+    ///
+    /// # SECURITY: `health_fn` MUST be side-effect-free (issue #828)
+    ///
+    /// `try_invoke_contract` is a **real** cross-contract call, not a
+    /// read-only host-function simulation. Any state-mutating entry point
+    /// named by `health_fn` will execute for real as a consequence of
+    /// merely registering the target contract. This includes arbitrary
+    /// admin toggles, resets, `increment`-style entry points, or any
+    /// other no-arg state-mutating function exposed on the target under
+    /// a plausible-sounding name — whether through admin operator error,
+    /// a compromised admin key, or a misleading naming convention on the
+    /// target contract itself.
+    ///
+    /// To mitigate this risk, `health_fn` is restricted to a fixed
+    /// allow-list of symbols that conventionally denote side-effect-free
+    /// liveness probes: `health` or `ping`. Any other symbol is rejected
+    /// with [`RegistryError::InvalidHealthFn`] **before** any
+    /// cross-contract call is performed, so a non-allow-listed symbol
+    /// cannot cause state changes on the target.
+    ///
+    /// Callers remain responsible for ensuring that the target
+    /// contract's implementation of `health` or `ping` is itself
+    /// side-effect-free. The allow-list is a name-shape guardrail, not
+    /// a behavioural guarantee — a target could still implement `health`
+    /// in a state-mutating way.
+    ///
+    /// # Errors
+    /// * [`RegistryError::InvalidHealthFn`] — `health_fn` was supplied
+    ///   but its symbol is not in the `health` / `ping` allow-list.
+    /// * [`RegistryError::ContractUnreachable`] — `health_fn` was
+    ///   allow-listed, but the target contract either does not
+    ///   implement it or the invocation failed.
+    /// * [`RegistryError::Unauthorized`] — if `caller` is not the admin.
+    /// * [`RegistryError::InvalidVersion`] — if `version` is 0 or not
+    ///   greater than all existing versions for `name`.
+    /// * [`RegistryError::AlreadyRegistered`] — if `(name, version)`
+    ///   is already registered.
+    /// * [`RegistryError::NotInitialized`] — if the registry has not
+    ///   been initialized.
     pub fn register_with_check(
         env: Env,
         caller: Address,
@@ -155,6 +200,17 @@ impl RouterRegistry {
         Self::require_admin(&env, &caller)?;
 
         if let Some(fn_sym) = health_fn {
+            // SECURITY (issue #828): `try_invoke_contract` is a real
+            // cross-contract call — not a read-only simulation — so the
+            // symbol chosen here is reachable arbitrary code on the
+            // target. Restrict to the documented allow-list BEFORE any
+            // call is dispatched so a non-allow-listed symbol cannot
+            // trigger state-mutating entry points on the target during
+            // registration.
+            if !Self::is_allowed_health_fn(&env, &fn_sym) {
+                return Err(RegistryError::InvalidHealthFn);
+            }
+
             let args: Vec<Val> = Vec::new(&env);
             if env
                 .try_invoke_contract::<Val, Val>(&address, &fn_sym, args)
@@ -606,6 +662,14 @@ impl RouterRegistry {
             RegistryError::InvalidVersion => router_common::BatchItemError::InvalidName,
             RegistryError::Unauthorized => router_common::BatchItemError::Unauthorized,
             RegistryError::InvalidConstraint => router_common::BatchItemError::InvalidMetadata,
+            // `InvalidHealthFn` and other variants are intentionally not
+            // listed here: `bulk_register` only invokes
+            // `validate_registration` and `register_entry`, never
+            // `register_with_check`, so these discriminants cannot be
+            // produced inside a batch and the catch-all is unreachable for
+            // them in practice. If a future code path on this contract can
+            // emit these errors during a bulk operation, add an explicit
+            // arm for it rather than relying on the catch-all.
             _ => router_common::BatchItemError::Custom(soroban_sdk::String::from_str(env, "Error")),
         }
     }
@@ -680,6 +744,22 @@ impl RouterRegistry {
         );
 
         Ok(())
+    }
+
+    /// Returns `true` when `fn_sym` is in the documented allow-list of
+    /// side-effect-free liveness-probe names accepted by
+    /// [`RouterRegistry::register_with_check`].
+    ///
+    /// Currently: `health` and `ping`. The allow-list is intentionally
+    /// small so that the registry cannot be coerced into invoking an
+    /// arbitrary — and potentially state-mutating — entry point on the
+    /// target contract via a misleading or accidental name (issue #828).
+    fn is_allowed_health_fn(env: &Env, fn_sym: &Symbol) -> bool {
+        // Dereference `&Symbol` to `Symbol` to compare `Symbol == Symbol`
+        // rather than `Symbol == &Symbol` — the latter requires
+        // `PartialEq<&Symbol>` which is not part of the documented surface
+        // for `soroban_sdk::Symbol` across SDK versions.
+        *fn_sym == Symbol::new(env, "health") || *fn_sym == Symbol::new(env, "ping")
     }
 
     fn require_admin(env: &Env, caller: &Address) -> Result<(), RegistryError> {
@@ -1626,11 +1706,23 @@ mod tests {
 
     #[contractimpl]
     impl MockHealthContract {
-        pub fn version(_env: Env) -> u32 {
-            1
-        }
-
         pub fn health(_env: Env) {}
+
+        pub fn ping(_env: Env) {}
+    }
+
+    /// A contract that *intentionally* does not implement the allow-listed
+    /// `health` / `ping` symbols, used to verify that an allow-listed
+    /// symbol returns `ContractUnreachable` (not `InvalidHealthFn`) when the
+    /// function is missing on the target.
+    #[contract]
+    pub struct MockNoHealthContract;
+
+    #[contractimpl]
+    impl MockNoHealthContract {
+        pub fn some_other_fn(_env: Env) -> u32 {
+            42
+        }
     }
 
     #[test]
@@ -1649,7 +1741,8 @@ mod tests {
         let (env, admin, client) = setup();
         let mock_id = env.register_contract(None, MockHealthContract);
         let name = String::from_str(&env, "oracle");
-        let health_fn = Symbol::new(&env, "version");
+        // `health` is in the allow-list and MockHealthContract implements it.
+        let health_fn = Symbol::new(&env, "health");
         let result = client.try_register_with_check(&admin, &name, &1, &mock_id, &Some(health_fn));
         assert_eq!(result, Ok(Ok(())));
         let entry = client.get(&name, &1);
@@ -1657,14 +1750,92 @@ mod tests {
     }
 
     #[test]
-    fn test_register_with_check_missing_health_fn_fails() {
+    fn test_register_with_check_ping_fn_succeeds() {
         let (env, admin, client) = setup();
         let mock_id = env.register_contract(None, MockHealthContract);
         let name = String::from_str(&env, "oracle");
-        let health_fn = Symbol::new(&env, "nonexistent");
+        // `ping` is in the allow-list and MockHealthContract implements it.
+        let health_fn = Symbol::new(&env, "ping");
+        let result = client.try_register_with_check(&admin, &name, &1, &mock_id, &Some(health_fn));
+        assert_eq!(result, Ok(Ok(())));
+        let entry = client.get(&name, &1);
+        assert_eq!(entry.address, mock_id);
+    }
+
+    #[test]
+    fn test_register_with_check_non_allowlisted_symbol_rejected() {
+        // Issue #828: arbitrary symbols must be rejected BEFORE any
+        // cross-contract call so they cannot trigger state-mutating entry
+        // points on the target during registration. The list below mixes
+        // plausible admin-toggle / increment function names (which on a
+        // hostile target contract WOULD mutate state) with arbitrary
+        // non-existent names (which test the same rejection path). The
+        // rejection happens pre-invocation, so the function does not need
+        // to actually exist on the target — we just need it to NOT be in
+        // the `health`/`ping` allow-list.
+        for sym_str in ["reset", "pause", "unpause", "increment", "nonexistent", "init"] {
+            let (env, admin, client) = setup();
+            let mock_id = env.register_contract(None, MockHealthContract);
+            let name = String::from_str(&env, "oracle");
+            let health_fn = Symbol::new(&env, sym_str);
+            let result =
+                client.try_register_with_check(&admin, &name, &1, &mock_id, &Some(health_fn));
+            assert_eq!(
+                result,
+                Err(Ok(RegistryError::InvalidHealthFn)),
+                "non-allow-listed symbol '{}' must be rejected",
+                sym_str
+            );
+            // Contract must NOT have been registered — the rejection happens
+            // before the entry is stored.
+            assert_eq!(client.try_get(&name, &1), Err(Ok(RegistryError::NotFound)));
+        }
+    }
+
+    #[test]
+    fn test_register_with_check_allowlisted_target_missing_fn_fails() {
+        // Allow-listed symbol whose target implementation is missing
+        // returns ContractUnreachable (after the allow-list check).
+        let (env, admin, client) = setup();
+        let mock_id = env.register_contract(None, MockNoHealthContract);
+        let name = String::from_str(&env, "oracle");
+        // `health` is allow-listed, but MockNoHealthContract does NOT
+        // implement it, so try_invoke_contract fails.
+        let health_fn = Symbol::new(&env, "health");
         let result = client.try_register_with_check(&admin, &name, &1, &mock_id, &Some(health_fn));
         assert_eq!(result, Err(Ok(RegistryError::ContractUnreachable)));
         assert_eq!(client.try_get(&name, &1), Err(Ok(RegistryError::NotFound)));
+    }
+
+    #[test]
+    fn test_register_with_check_unauthorized_fail_still_returns_unauthorized() {
+        // Admin-gating must run BEFORE the allow-list check so a
+        // non-admin cannot learn anything about the allow-list via
+        // differential error responses. We exercise both paths:
+        // (a) non-admin caller with an allow-listed symbol
+        // (b) non-admin caller with a non-allow-listed symbol
+        // Both must return Unauthorized and never InvalidHealthFn or
+        // ContractUnreachable — the admin check is the only gate that
+        // runs before everything else here.
+        for sym_str in ["health", "reset"] {
+            let (env, _admin, client) = setup();
+            let mock_id = env.register_contract(None, MockHealthContract);
+            let name = String::from_str(&env, "oracle");
+            let attacker = Address::generate(&env);
+            let result = client.try_register_with_check(
+                &attacker,
+                &name,
+                &1,
+                &mock_id,
+                &Some(Symbol::new(&env, sym_str)),
+            );
+            assert_eq!(
+                result,
+                Err(Ok(RegistryError::Unauthorized)),
+                "non-admin caller with symbol '{}' must see Unauthorized, not any allow-list error",
+                sym_str
+            );
+        }
     }
 
     // ── Issue #644: version constraint parsing edge cases ────────────────────

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -846,6 +846,8 @@ Each contract defines its own `#[contracterror]` enum. Use the tables below as t
 | `VersionNotFound` | `8` | Deprecating a version that does not exist | Verify version list with `versions(name)` first |
 | `InvalidConstraint` | `9` | Constraint string format is invalid | Validate/normalize constraint syntax before calling |
 | `AllVersionsDeprecated` | `10` | Lookup finds only deprecated versions for a name | Register a new active version or allow deprecated fallback intentionally |
+| `ContractUnreachable` | `11` | `register_with_check` failed to invoke the supplied health function on the target address | Confirm the target contract exposes the allow-listed `health` or `ping` function and that it returns successfully |
+| `InvalidHealthFn` | `12` | `register_with_check` rejected `health_fn` because it was not in the `health` / `ping` allow-list (issue #828) | Pass `None` or use one of `health` / `ping`; pass-through arbitrary symbols are no longer accepted to prevent state-mutating entry points being invoked on the target during registration |
 
 ### router-access (`AccessError`)
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -140,7 +140,8 @@ Uses range-based codes to distinguish error categories.
 | 9    | `InvalidConstraint` |
 | 10   | `AllVersionsDeprecated` |
 | 11   | `ContractUnreachable` |
-| **12** | ← next available |
+| 12   | `InvalidHealthFn` |
+| **13** | ← next available |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #828. `RouterRegistry::register_with_check` previously invoked an admin-supplied `Symbol` (named `health_fn`) on the target contract via `try_invoke_contract` with no naming restriction. Because `try_invoke_contract` is a real cross-contract call — not a read-only host-function simulation — any state-mutating entry point named by `health_fn` was executed for real as a side effect of merely registering the target contract. This includes arbitrary admin toggles, resets, `increment`-style entry points, or any no-arg state-mutating function exposed on the target under a plausible-sounding name, whether through admin operator error, a compromised admin key, or a misleading naming convention on the target contract itself.

This PR introduces a **fixed allow-list** of conventionally side-effect-free liveness-probe symbols — currently `health` or `ping` — and returns the new `RegistryError::InvalidHealthFn = 12` for any other symbol **before** any cross-contract call is dispatched, so a non-allow-listed symbol cannot trigger state changes on the target. The doc comment on `register_with_check` is updated with explicit security notes documenting the invariant and the residual trust boundary on third-party implementations of `health` / `ping` (the allow-list is a name-shape guardrail, not a behavioural guarantee).

## Changes

### `contracts/router-registry/src/lib.rs`

- New `RegistryError::InvalidHealthFn = 12` variant (added at the end so existing discriminants are unchanged — non-breaking for already-published ABIs).
- `register_with_check` now rejects non-allow-listed `health_fn` symbols with `InvalidHealthFn` BEFORE dispatching the cross-contract call. `ContractUnreachable` is still returned when the allow-listed symbol's target implementation is missing or fails.
- New private helper `is_allowed_health_fn` that compares against `Symbol::new(env, "health")` and `Symbol::new(env, "ping")` via `Symbol == Symbol` equality (dereferencing `&Symbol` to `Symbol`, which is `Copy`).
- Doc comment on `register_with_check` rewritten with an explicit `SECURITY` section describing why this matters (issue #828), the allow-list contract, the residual trust boundary on third-party target implementations, and the full error matrix.
- `registry_error_to_batch` gains a comment explaining why `InvalidHealthFn` intentionally falls through to the catch-all arm (the variant cannot be produced inside `bulk_register`, which never calls `register_with_check`).

### Tests added

- `test_register_with_check_ping_fn_succeeds` — `ping` symbol against `MockHealthContract` succeeds.
- `test_register_with_check_non_allowlisted_symbol_rejected` — iterates over plausible attack and arbitrary names (`reset`, `pause`, `unpause`, `increment`, `nonexistent`, `init`) and asserts `InvalidHealthFn` for each, plus that no entry was registered (rejection happens pre-invocation).
- `test_register_with_check_allowlisted_target_missing_fn_fails` — `health` symbol against `MockNoHealthContract` (which intentionally does NOT implement `health`) returns `ContractUnreachable`, not `InvalidHealthFn`.
- `test_register_with_check_unauthorized_fail_still_returns_unauthorized` — non-admin caller gets `Unauthorized` regardless of whether `health_fn` is allow-listed (`health`) or not (`reset`); this verifies the admin check runs before the allow-list so there is no info-leak via differential error responses.

### Tests updated

- `MockHealthContract` now exposes only `health()` and `ping()` (the previously-stubbed `version()` was removed as dead code — every remaining test that mentions `"version"` now passes it as a *rejected* symbol, so `try_invoke_contract` is never dispatched).
- New mock `MockNoHealthContract` exposes only `some_other_fn()` for the missing-fn test.

### Docs

- `docs/error-codes.md` — `router-registry` table now lists `12 InvalidHealthFn` and the `next available` marker bumped to `13`.
- `docs/api-reference.md` — `RegistryError` table adds rows for code `11 ContractUnreachable` and `12 InvalidHealthFn`.
- `CHANGELOG.md` — `Unreleased` section gains a registry entry for the new variant and a `Security` entry describing the behaviour change.

## Backwards Compatibility / Migration

This is a **breaking behaviour change** for callers that previously passed any symbol other than `health` or `ping` to `register_with_check` — those calls will now return `InvalidHealthFn` instead of dispatching the cross-contract call. Affected callers should:

1. Switch their target contracts to expose either `health` or `ping` (one is sufficient), OR
2. Switch to passing `None` to skip the liveness probe entirely (this preserves the prior effective behaviour of `register`), OR
3. Pass `name` to plain `RouterRegistry::register` if no liveness check is desired.

Note: the new error variant `InvalidHealthFn = 12` is added at the end of `RegistryError` with an explicit discriminant; existing variants keep their discriminants, so the on-chain ABI for already-deployed registries remains readable for error mapping.

## Reproduction (pre-fix)

A hostile target contract can expose a state-mutating 0-arg function under any plausible name (e.g. `reset`, `pause`, `increment`, `init`). As registry admin, calling `register_with_check(name, version, target_addr, Some(Symbol("reset")))` will execute the hostile `reset()` on the target as part of the registration transaction.

After this fix, the same call returns `InvalidHealthFn` BEFORE any cross-contract call is dispatched — the malicious `reset()` never runs.

## Verification

The change is confined to the router-registry crate plus three documentation files, so the blast radius is small. The upstream `ci.yml` workflow runs `cargo test` across the workspace and `wasm-size-check.yml` validates WASM build size; both will exercise this fix on push.
</content>
</invoke>