### PR TITLE
fix: bound rate-limit map growth, validate expiry/hierarchy depth, keep role counts accurate

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -42,6 +42,8 @@ pub enum AccessError {
     CannotBlacklistAdmin = 7,
     DestinationAlreadyHasRole = 8,
     HierarchyCycle = 9,
+    InvalidExpiry = 10,
+    HierarchyTooDeep = 11,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -327,6 +329,13 @@ impl RouterAccess {
             return Err(AccessError::CannotBlacklistAdmin);
         }
 
+        // Decrement RoleMemberCount for every role the target currently holds
+        // actively (directly), since has_role_internal/get_role_members will
+        // stop counting them the moment they're blacklisted — must be read
+        // *before* the Blacklisted flag is set below, or has_direct_role_internal
+        // would already see them as inactive.
+        Self::adjust_role_member_counts_for_blacklist_change(&env, &target, false);
+
         env.storage()
             .instance()
             .set(&DataKey::Blacklisted(target.clone()), &true);
@@ -344,6 +353,13 @@ impl RouterAccess {
         env.storage()
             .instance()
             .remove(&DataKey::Blacklisted(target.clone()));
+
+        // Re-increment RoleMemberCount for every role the target still
+        // actively (directly, non-expired) holds now that the blacklist gate
+        // is lifted, keeping get_role_member_count in sync with
+        // get_role_members/has_role_internal.
+        Self::adjust_role_member_counts_for_blacklist_change(&env, &target, true);
+
         env.events().publish(
             (Symbol::new(
                 &env,
@@ -352,6 +368,35 @@ impl RouterAccess {
             target,
         );
         Ok(())
+    }
+
+    /// Adjusts `RoleMemberCount` for every role in `target`'s `AddressRoles`
+    /// list that it directly and actively (non-expired) holds, by +1 (when
+    /// `increment` is true, i.e. on unblacklist) or -1 (on blacklist).
+    fn adjust_role_member_counts_for_blacklist_change(env: &Env, target: &Address, increment: bool) {
+        let roles: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AddressRoles(target.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+
+        for role in roles.iter() {
+            if Self::has_direct_role_internal(env, target, &role) {
+                let current: u32 = env
+                    .storage()
+                    .instance()
+                    .get::<DataKey, u32>(&DataKey::RoleMemberCount(role.clone()))
+                    .unwrap_or(0u32);
+                let new_count = if increment {
+                    current.saturating_add(1)
+                } else {
+                    current.saturating_sub(1)
+                };
+                env.storage()
+                    .instance()
+                    .set(&DataKey::RoleMemberCount(role.clone()), &new_count);
+            }
+        }
     }
 
     pub fn is_blacklisted(env: Env, target: Address) -> bool {
@@ -603,20 +648,34 @@ impl RouterAccess {
             AccessError::AlreadyHasRole => router_common::BatchItemError::AlreadyExists,
             AccessError::Unauthorized => router_common::BatchItemError::Unauthorized,
             AccessError::Blacklisted => router_common::BatchItemError::InvalidMetadata,
+            AccessError::InvalidExpiry => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "InvalidExpiry"),
+            ),
             _ => router_common::BatchItemError::Custom(soroban_sdk::String::from_str(env, "Error")),
         }
     }
 
+    /// Validates a prospective `role -> parent_role` edge: rejects it if it
+    /// would create a cycle, or if it would make the longest ancestor chain
+    /// reachable from `role` reach/exceed `MAX_HIERARCHY_DEPTH` — the same
+    /// bound `has_role_internal` enforces when walking up from a role, so a
+    /// chain accepted here is guaranteed to be fully walkable there.
     fn ensure_no_role_parent_cycle(
         env: &Env,
         role: &String,
         parent_role: &String,
     ) -> Result<(), AccessError> {
         let mut current = parent_role.clone();
+        // The role -> parent_role edge itself is depth 1.
+        let mut depth: u32 = 1;
 
         loop {
             if &current == role {
                 return Err(AccessError::HierarchyCycle);
+            }
+
+            if depth >= MAX_HIERARCHY_DEPTH {
+                return Err(AccessError::HierarchyTooDeep);
             }
 
             match env
@@ -624,7 +683,10 @@ impl RouterAccess {
                 .instance()
                 .get::<DataKey, String>(&DataKey::RoleParent(current.clone()))
             {
-                Some(parent) => current = parent,
+                Some(parent) => {
+                    current = parent;
+                    depth += 1;
+                }
                 None => return Ok(()),
             }
         }
@@ -657,7 +719,11 @@ impl RouterAccess {
                 .get::<DataKey, u64>(&DataKey::RoleExpiry(role.clone(), account.clone()));
 
             let requested_expiry = match expires_in {
-                Some(seconds) => env.ledger().timestamp() + seconds,
+                Some(seconds) => env
+                    .ledger()
+                    .timestamp()
+                    .checked_add(seconds)
+                    .ok_or(AccessError::InvalidExpiry)?,
                 None => u64::MAX,
             };
 
@@ -671,7 +737,11 @@ impl RouterAccess {
         Self::track_role_in_all_roles(env, role);
 
         let expiry_timestamp = match expires_in {
-            Some(seconds) => env.ledger().timestamp() + seconds,
+            Some(seconds) => env
+                .ledger()
+                .timestamp()
+                .checked_add(seconds)
+                .ok_or(AccessError::InvalidExpiry)?,
             None => u64::MAX,
         };
 

--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -100,6 +100,16 @@ pub struct CircuitBreakerState {
     pub is_half_open: bool,
 }
 
+/// Per-route state combining per-caller rate limits with the route's circuit
+/// breaker, stored under a single `DataKey::RouteCallState(route)` key.
+///
+/// `rate_limits` grows one entry per distinct caller that has ever invoked
+/// `pre_call` on a rate-limited route, with no TTL of its own. To bound this,
+/// `pre_call` lazily evicts entries whose rate-limit window has been idle for
+/// longer than `RATE_LIMIT_STALE_WINDOW_MULTIPLIER` × the route's configured
+/// `window_seconds` every time it loads this state, so long-idle callers don't
+/// permanently inflate the read/write cost of every other caller's calls on
+/// the route.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RouteCallState {
@@ -108,6 +118,10 @@ pub struct RouteCallState {
     /// Route-level circuit breaker state
     pub circuit_breaker: CircuitBreakerState,
 }
+
+/// Multiplier applied to a route's `window_seconds` to decide when an idle
+/// caller's rate-limit entry is considered stale and safe to evict.
+const RATE_LIMIT_STALE_WINDOW_MULTIPLIER: u64 = 4;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -316,7 +330,12 @@ impl RouterMiddleware {
                 return Err(MiddlewareError::RouteDisabled);
             }
 
-            let mut state_changed = false;
+            let mut state_changed = Self::prune_stale_rate_limits(
+                &env,
+                &mut route_call_state.rate_limits,
+                env.ledger().timestamp(),
+                config.window_seconds,
+            );
             if config.failure_threshold > 0 && route_call_state.circuit_breaker.is_open {
                 let now = env.ledger().timestamp();
                 let recovers = config.recovery_window_seconds > 0
@@ -1152,6 +1171,35 @@ impl RouterMiddleware {
         } else {
             Ok(true)
         }
+    }
+
+    /// Evicts entries from `rate_limits` whose window has been idle for
+    /// longer than `RATE_LIMIT_STALE_WINDOW_MULTIPLIER` × `base_window_seconds`,
+    /// bounding the map's growth to actively-rate-limited callers. Returns
+    /// `true` if any entry was removed (so the caller knows to persist the
+    /// pruned state).
+    fn prune_stale_rate_limits(
+        env: &Env,
+        rate_limits: &mut Map<Address, RateLimitState>,
+        now: u64,
+        base_window_seconds: u64,
+    ) -> bool {
+        let stale_after = base_window_seconds
+            .saturating_mul(RATE_LIMIT_STALE_WINDOW_MULTIPLIER)
+            .max(1);
+
+        let mut stale_callers: Vec<Address> = Vec::new(env);
+        for (caller, state) in rate_limits.iter() {
+            if now >= state.window_start.saturating_add(stale_after) {
+                stale_callers.push_back(caller);
+            }
+        }
+
+        for caller in stale_callers.iter() {
+            rate_limits.remove(caller);
+        }
+
+        !stale_callers.is_empty()
     }
 }
 


### PR DESCRIPTION
Closes #815
Closes #816
Closes #817
Closes #818

## #815 — unbounded per-caller rate_limits map
`pre_call` now lazily evicts `RouteCallState.rate_limits` entries whose window has been idle for longer than 4x the route's `window_seconds` every time it loads the state, bounding storage/read cost to actively-rate-limited callers instead of every distinct caller in the route's history.

## #816 — grant_role expiry overflow panic
Both unchecked `timestamp() + seconds` additions in `grant_role_internal` (the duplicate-check computation and the actual `expiry_timestamp`) now use `checked_add`, returning a new `AccessError::InvalidExpiry` instead of trapping the host invocation. `grant_role_batch` already converts arbitrary `AccessError`s to a `BatchItemError` per item, so this is now recorded as a per-item failure rather than aborting the batch.

## #817 — hierarchy chains deeper than MAX_HIERARCHY_DEPTH
`ensure_no_role_parent_cycle` now also counts the depth of the chain being formed while walking from `parent_role`, rejecting the edge with a new `AccessError::HierarchyTooDeep` if it would make `role`'s ancestor chain reach/exceed `MAX_HIERARCHY_DEPTH` (16) — the same bound `has_role_internal` enforces, so any chain `set_role_parent` accepts is guaranteed to be fully walkable by `has_role`.

## #818 — get_role_member_count drifts once a member is blacklisted
`blacklist`/`unblacklist` now walk the target's `AddressRoles` and adjust each actively-held role's `RoleMemberCount` by minus/plus 1, so the stored counter stays consistent with `get_role_members`/`has_role_internal` instead of over-counting blacklisted holders.