### PR TITLE
Fix rate-limit/call-log bugs, wire up dead modules, add execute() success-path tests

### DIFF
--- a/contracts/router-execution/src/lib.rs
+++ b/contracts/router-execution/src/lib.rs
@@ -1237,4 +1237,148 @@ mod tests {
         let (_, mult) = client.backoff_config();
         assert_eq!(mult, 10_000);
     }
+
+    // ── Issue #811: execute() success path coverage ──────────────────────────
+    //
+    // Every other `execute()` test drives the failure/exhaustion branch by
+    // calling an unregistered target. These tests register a lightweight
+    // in-process contract so `try_invoke_contract` returns `Ok(_)` and the
+    // success branch (~lines 370-385) is actually exercised.
+
+    #[contract]
+    pub struct MockTarget;
+
+    #[contractimpl]
+    impl MockTarget {
+        /// A trivial no-arg function that always succeeds.
+        pub fn ping(_env: Env) {}
+    }
+
+    #[contract]
+    pub struct FlakyTarget;
+
+    #[contractimpl]
+    impl FlakyTarget {
+        /// Fails on the first invocation, succeeds on every call after that.
+        /// Used to exercise the retry-then-succeed path of `execute()`.
+        pub fn ping(env: Env) {
+            let key = Symbol::new(&env, "calls");
+            let count: u32 = env.storage().instance().get(&key).unwrap_or(0);
+            env.storage().instance().set(&key, &(count + 1));
+            if count == 0 {
+                panic!("flaky: first call fails");
+            }
+        }
+    }
+
+    #[test]
+    fn test_execute_success_path() {
+        let (env, _admin, client) = setup();
+        let mock_id = env.register_contract(None, MockTarget);
+        let caller = Address::generate(&env);
+        let function = Symbol::new(&env, "ping");
+
+        let request = ExecutionRequest {
+            target: mock_id.clone(),
+            function: function.clone(),
+            simulate_first: false,
+            max_retries: 0,
+        };
+
+        let result = client.execute(&caller, &request);
+        assert!(result.success);
+        assert_eq!(result.attempts, 1);
+        assert_eq!(result.target, mock_id);
+        assert_eq!(result.function, function);
+        assert!(!result.simulated);
+
+        // TotalExecutions should have incremented; no errors recorded.
+        let (total_execs, total_errors) = client.stats();
+        assert_eq!(total_execs, 1);
+        assert_eq!(total_errors, 0);
+
+        // The new ExecutionRecord should be present in history, success=true.
+        let history = client.get_execution_history(&1);
+        assert_eq!(history.len(), 1);
+        let record = history.get(0).unwrap();
+        assert!(record.success);
+        assert_eq!(record.target, mock_id);
+        assert_eq!(record.function, function);
+
+        // An `execution_result` event should be present with the expected payload.
+        let all_events = env.events().all();
+        let exec_event = all_events
+            .iter()
+            .find(|e| {
+                let topic: Symbol = e.1.get(0).unwrap().into_val(&env);
+                topic == Symbol::new(&env, router_common::EVENT_EXECUTION_RESULT)
+            })
+            .expect("execution_result event not found");
+        let (evt_target, evt_function, evt_success, evt_attempts): (Address, Symbol, bool, u32) =
+            exec_event.2.into_val(&env);
+        assert_eq!(evt_target, mock_id);
+        assert_eq!(evt_function, function);
+        assert!(evt_success);
+        assert_eq!(evt_attempts, 1);
+    }
+
+    #[test]
+    fn test_execute_retry_then_succeeds() {
+        // setup() initializes with backoff_base_ms=500, backoff_multiplier=200 (2x).
+        let (env, _admin, client) = setup();
+        let mock_id = env.register_contract(None, FlakyTarget);
+        let caller = Address::generate(&env);
+        let function = Symbol::new(&env, "ping");
+
+        let request = ExecutionRequest {
+            target: mock_id.clone(),
+            function: function.clone(),
+            simulate_first: false,
+            max_retries: 2,
+        };
+
+        let result = client.execute(&caller, &request);
+        assert!(result.success);
+        // First attempt fails, second attempt (the retry) succeeds.
+        assert_eq!(result.attempts, 2);
+
+        let (total_execs, _) = client.stats();
+        assert_eq!(total_execs, 1);
+
+        let history = client.get_execution_history(&1);
+        assert_eq!(history.len(), 1);
+        assert!(history.get(0).unwrap().success);
+
+        let all_events = env.events().all();
+
+        // The failed first attempt should have emitted an `execution_retry` event
+        // carrying the computed backoff delay.
+        let retry_event = all_events
+            .iter()
+            .find(|e| {
+                let topic: Symbol = e.1.get(0).unwrap().into_val(&env);
+                topic == Symbol::new(&env, router_common::EVENT_EXECUTION_RETRY)
+            })
+            .expect("execution_retry event not found");
+        let (retry_target, retry_function, retry_attempts, delay_ms): (Address, Symbol, u32, u64) =
+            retry_event.2.into_val(&env);
+        assert_eq!(retry_target, mock_id);
+        assert_eq!(retry_function, function);
+        assert_eq!(retry_attempts, 1);
+        // attempt_index = attempts - 1 = 0 -> delay == backoff_base_ms unchanged.
+        assert_eq!(delay_ms, 500);
+
+        // The eventual success should still emit `execution_result` with attempts=2.
+        let exec_event = all_events
+            .iter()
+            .find(|e| {
+                let topic: Symbol = e.1.get(0).unwrap().into_val(&env);
+                topic == Symbol::new(&env, router_common::EVENT_EXECUTION_RESULT)
+            })
+            .expect("execution_result event not found");
+        let (_, _, evt_success, evt_attempts): (Address, Symbol, bool, u32) =
+            exec_event.2.into_val(&env);
+        assert!(evt_success);
+        assert_eq!(evt_attempts, 2);
+    }
 }

--- a/contracts/router-middleware/src/call_log.rs
+++ b/contracts/router-middleware/src/call_log.rs
@@ -81,3 +81,92 @@ pub fn clear(env: &Env, route: &String) {
         .instance()
         .remove(&DataKey::CallLogSummary(route.clone()));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RouterMiddleware;
+    use soroban_sdk::testutils::Address as _;
+
+    fn env_with_contract() -> (Env, soroban_sdk::Address) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, RouterMiddleware);
+        (env, contract_id)
+    }
+
+    fn cfg(log_retention: u32) -> RouteConfig {
+        RouteConfig {
+            max_calls_per_window: 0,
+            window_seconds: 0,
+            enabled: true,
+            failure_threshold: 0,
+            recovery_window_seconds: 0,
+            log_retention,
+            burst_allowance: 0,
+        }
+    }
+
+    #[test]
+    fn append_is_noop_when_log_retention_zero() {
+        let (env, contract_id) = env_with_contract();
+        let caller = soroban_sdk::Address::generate(&env);
+        let route = String::from_str(&env, "route");
+        env.as_contract(&contract_id, || {
+            append(&env, &caller, &route, true, &cfg(0));
+            assert!(env
+                .storage()
+                .instance()
+                .get::<DataKey, CallLogState>(&DataKey::CallLog(route.clone()))
+                .is_none());
+            assert!(env
+                .storage()
+                .instance()
+                .get::<DataKey, CallLogSummary>(&DataKey::CallLogSummary(route.clone()))
+                .is_none());
+        });
+    }
+
+    #[test]
+    fn append_updates_summary_counts() {
+        let (env, contract_id) = env_with_contract();
+        let caller = soroban_sdk::Address::generate(&env);
+        let route = String::from_str(&env, "route");
+        env.as_contract(&contract_id, || {
+            append(&env, &caller, &route, true, &cfg(5));
+            append(&env, &caller, &route, false, &cfg(5));
+            let summary: CallLogSummary = env
+                .storage()
+                .instance()
+                .get(&DataKey::CallLogSummary(route.clone()))
+                .unwrap();
+            assert_eq!(summary.total_calls, 2);
+            assert_eq!(summary.success_count, 1);
+            assert_eq!(summary.failure_count, 1);
+        });
+    }
+
+    #[test]
+    fn clear_removes_both_log_and_summary() {
+        // Regression test for issue #812: reset must not leave a stale
+        // CallLogSummary behind after the CallLog itself is cleared.
+        let (env, contract_id) = env_with_contract();
+        let caller = soroban_sdk::Address::generate(&env);
+        let route = String::from_str(&env, "route");
+        env.as_contract(&contract_id, || {
+            append(&env, &caller, &route, true, &cfg(5));
+            assert!(env
+                .storage()
+                .instance()
+                .has(&DataKey::CallLogSummary(route.clone())));
+            assert!(env.storage().instance().has(&DataKey::CallLog(route.clone())));
+
+            clear(&env, &route);
+
+            assert!(!env
+                .storage()
+                .instance()
+                .has(&DataKey::CallLogSummary(route.clone())));
+            assert!(!env.storage().instance().has(&DataKey::CallLog(route.clone())));
+        });
+    }
+}

--- a/contracts/router-middleware/src/circuit_breaker.rs
+++ b/contracts/router-middleware/src/circuit_breaker.rs
@@ -72,12 +72,18 @@ pub fn handle_failure(
     }
 }
 
-/// Handle a success in `post_call`: close circuit if in half-open state,
-/// or reset failure count if failures exist.
-pub fn handle_success(route_call_state: &mut RouteCallState) {
+/// Handle a success in `post_call`: close circuit if in half-open state
+/// (emitting a `circuit_closed` event and clearing `opened_at`), or reset
+/// the failure count if failures exist.
+pub fn handle_success(env: &Env, route: &String, route_call_state: &mut RouteCallState) {
     if route_call_state.circuit_breaker.is_half_open {
         route_call_state.circuit_breaker.is_half_open = false;
         route_call_state.circuit_breaker.failure_count = 0;
+        route_call_state.circuit_breaker.opened_at = 0;
+        env.events().publish(
+            (Symbol::new(env, router_common::EVENT_CIRCUIT_CLOSED),),
+            route.clone(),
+        );
     } else if !route_call_state.circuit_breaker.is_open
         && route_call_state.circuit_breaker.failure_count > 0
     {
@@ -115,5 +121,150 @@ pub fn default_route_call_state(env: &Env) -> RouteCallState {
             is_open: false,
             is_half_open: false,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RouterMiddleware;
+    use soroban_sdk::testutils::{Events, Ledger};
+    use soroban_sdk::IntoVal;
+
+    fn env_with_contract() -> (Env, soroban_sdk::Address) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, RouterMiddleware);
+        (env, contract_id)
+    }
+
+    fn cfg(failure_threshold: u32, recovery_window_seconds: u64) -> RouteConfig {
+        RouteConfig {
+            max_calls_per_window: 0,
+            window_seconds: 0,
+            enabled: true,
+            failure_threshold,
+            recovery_window_seconds,
+            log_retention: 0,
+            burst_allowance: 0,
+        }
+    }
+
+    #[test]
+    fn handle_failure_opens_circuit_at_threshold() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        env.as_contract(&contract_id, || {
+            let mut state = default_route_call_state(&env);
+            let config = cfg(2, 60);
+            handle_failure(&env, &route, &config, &mut state);
+            assert!(!state.circuit_breaker.is_open);
+            assert_eq!(state.circuit_breaker.failure_count, 1);
+
+            handle_failure(&env, &route, &config, &mut state);
+            assert!(state.circuit_breaker.is_open);
+            assert_eq!(state.circuit_breaker.failure_count, 2);
+        });
+    }
+
+    #[test]
+    fn check_and_transition_blocks_while_open_and_recovery_window_not_elapsed() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        env.ledger().set_timestamp(1000);
+        env.as_contract(&contract_id, || {
+            let mut state = default_route_call_state(&env);
+            state.circuit_breaker.is_open = true;
+            state.circuit_breaker.opened_at = 1000;
+            let config = cfg(1, 60);
+
+            let blocked = check_and_transition(&env, &route, &config, &mut state);
+            assert!(blocked);
+            assert!(state.circuit_breaker.is_open);
+        });
+    }
+
+    #[test]
+    fn check_and_transition_moves_to_half_open_after_recovery_window() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        env.ledger().set_timestamp(1000);
+        env.as_contract(&contract_id, || {
+            let mut state = default_route_call_state(&env);
+            state.circuit_breaker.is_open = true;
+            state.circuit_breaker.opened_at = 1000;
+            let config = cfg(1, 60);
+
+            env.ledger().set_timestamp(1060);
+            let blocked = check_and_transition(&env, &route, &config, &mut state);
+            assert!(!blocked);
+            assert!(!state.circuit_breaker.is_open);
+            assert!(state.circuit_breaker.is_half_open);
+        });
+    }
+
+    #[test]
+    fn handle_success_closes_circuit_from_half_open_and_emits_event() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        env.as_contract(&contract_id, || {
+            let mut state = default_route_call_state(&env);
+            state.circuit_breaker.is_half_open = true;
+            state.circuit_breaker.opened_at = 500;
+            state.circuit_breaker.failure_count = 3;
+
+            handle_success(&env, &route, &mut state);
+
+            assert!(!state.circuit_breaker.is_half_open);
+            assert_eq!(state.circuit_breaker.failure_count, 0);
+            assert_eq!(state.circuit_breaker.opened_at, 0);
+        });
+
+        let events = env.events().all();
+        let expected_topic = Symbol::new(&env, router_common::EVENT_CIRCUIT_CLOSED);
+        let found = events.iter().any(|e| {
+            let topic: Symbol = e.1.get(0).unwrap().into_val(&env);
+            topic == expected_topic
+        });
+        assert!(found, "circuit_closed event must be emitted");
+    }
+
+    #[test]
+    fn reset_clears_open_circuit_back_to_closed() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        env.as_contract(&contract_id, || {
+            let mut state = default_route_call_state(&env);
+            state.circuit_breaker.is_open = true;
+            state.circuit_breaker.failure_count = 5;
+            state.circuit_breaker.opened_at = 42;
+            env.storage()
+                .instance()
+                .set(&DataKey::RouteCallState(route.clone()), &state);
+
+            reset(&env, &route);
+
+            let after: RouteCallState = env
+                .storage()
+                .instance()
+                .get(&DataKey::RouteCallState(route.clone()))
+                .unwrap();
+            assert!(!after.circuit_breaker.is_open);
+            assert_eq!(after.circuit_breaker.failure_count, 0);
+            assert_eq!(after.circuit_breaker.opened_at, 0);
+        });
+    }
+
+    #[test]
+    fn reset_is_noop_when_no_state_exists() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        env.as_contract(&contract_id, || {
+            reset(&env, &route);
+            assert!(env
+                .storage()
+                .instance()
+                .get::<DataKey, RouteCallState>(&DataKey::RouteCallState(route.clone()))
+                .is_none());
+        });
     }
 }

--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -317,31 +317,22 @@ impl RouterMiddleware {
             }
 
             let mut state_changed = false;
-            if config.failure_threshold > 0 && route_call_state.circuit_breaker.is_open {
-                let now = env.ledger().timestamp();
-                let recovers = config.recovery_window_seconds > 0
-                    && now
-                        >= route_call_state.circuit_breaker.opened_at
-                            + config.recovery_window_seconds;
-                if !recovers {
+            if config.failure_threshold > 0 {
+                let was_open = route_call_state.circuit_breaker.is_open;
+                if circuit_breaker::check_and_transition(
+                    &env,
+                    &route,
+                    &config,
+                    &mut route_call_state,
+                ) {
                     return Err(MiddlewareError::CircuitOpen);
                 }
-                route_call_state.circuit_breaker.is_open = false;
-                route_call_state.circuit_breaker.is_half_open = true;
-                state_changed = true;
+                if was_open {
+                    state_changed = true;
+                }
             }
 
             if config.max_calls_per_window > 0 {
-                let now = env.ledger().timestamp();
-                let state: RateLimitState = route_call_state
-                    .rate_limits
-                    .get(caller.clone())
-                    .unwrap_or(RateLimitState {
-                        calls_in_window: 0,
-                        window_start: now,
-                        total_violations: 0,
-                    });
-
                 // Resolve effective limit: per-caller override takes precedence over
                 // the route-level default when a CallerRateLimit entry is present.
                 let (effective_limit, effective_window) = env
@@ -359,28 +350,18 @@ impl RouterMiddleware {
                         config.window_seconds,
                     ));
 
-                let window_elapsed = now >= state.window_start + effective_window;
-                let calls = if window_elapsed {
-                    0
-                } else {
-                    state.calls_in_window
-                };
-                let window_start = if window_elapsed {
-                    now
-                } else {
-                    state.window_start
-                };
+                let check = rate_limit::check_and_increment(
+                    &env,
+                    &caller,
+                    &route_call_state,
+                    effective_limit,
+                    effective_window,
+                );
+                route_call_state
+                    .rate_limits
+                    .set(caller.clone(), check.updated_state);
 
-                if calls >= effective_limit {
-                    route_call_state.rate_limits.set(
-                        caller.clone(),
-                        RateLimitState {
-                            calls_in_window: calls,
-                            window_start,
-                            total_violations: state.total_violations + 1,
-                        },
-                    );
-
+                if check.exceeded {
                     let strategy: RateLimitStrategy = env
                         .storage()
                         .instance()
@@ -410,14 +391,6 @@ impl RouterMiddleware {
                         }
                     }
                 } else {
-                    route_call_state.rate_limits.set(
-                        caller.clone(),
-                        RateLimitState {
-                            calls_in_window: calls + 1,
-                            window_start,
-                            total_violations: state.total_violations,
-                        },
-                    );
                     state_changed = true;
                 }
             }
@@ -485,156 +458,24 @@ impl RouterMiddleware {
             .instance()
             .get::<DataKey, RouteConfig>(&DataKey::RouteConfig(route.clone()))
         {
-            if config.log_retention > 0 {
-                let mut log: CallLogState = env
+            call_log::append(&env, &caller, &route, success, &config);
+
+            if config.failure_threshold > 0 {
+                let mut route_call_state: RouteCallState = env
                     .storage()
                     .instance()
-                    .get(&DataKey::CallLog(route.clone()))
-                    .unwrap_or(CallLogState {
-                        entries: Vec::new(&env),
-                        head: 0,
-                        count: 0,
-                    });
+                    .get(&DataKey::RouteCallState(route.clone()))
+                    .unwrap_or_else(|| circuit_breaker::default_route_call_state(&env));
 
-                let entry = CallLogEntry {
-                    caller: caller.clone(),
-                    timestamp: env.ledger().timestamp(),
-                    success,
-                    route: route.clone(),
-                };
-
-                let cap = config.log_retention;
-                let len = log.entries.len();
-                if len < cap {
-                    log.entries.push_back(entry);
-                } else {
-                    log.entries.set(log.head, entry);
-                    log.head = (log.head + 1) % cap;
-                }
-                log.count = log.count.saturating_add(1).min(cap);
-
-                env.storage()
-                    .instance()
-                    .set(&DataKey::CallLog(route.clone()), &log);
-
-                let mut summary: CallLogSummary = env
-                    .storage()
-                    .instance()
-                    .get(&DataKey::CallLogSummary(route.clone()))
-                    .unwrap_or(CallLogSummary {
-                        total_calls: 0,
-                        success_count: 0,
-                        failure_count: 0,
-                        last_call_timestamp: 0,
-                    });
-                summary.total_calls += 1;
                 if success {
-                    summary.success_count += 1;
+                    circuit_breaker::handle_success(&env, &route, &mut route_call_state);
                 } else {
-                    summary.failure_count += 1;
+                    circuit_breaker::handle_failure(&env, &route, &config, &mut route_call_state);
                 }
-                summary.last_call_timestamp = env.ledger().timestamp();
+
                 env.storage()
                     .instance()
-                    .set(&DataKey::CallLogSummary(route.clone()), &summary);
-            }
-        }
-
-        if !success {
-            if let Some(config) = env
-                .storage()
-                .instance()
-                .get::<DataKey, RouteConfig>(&DataKey::RouteConfig(route.clone()))
-            {
-                if config.failure_threshold > 0 {
-                    let mut route_call_state: RouteCallState = env
-                        .storage()
-                        .instance()
-                        .get(&DataKey::RouteCallState(route.clone()))
-                        .unwrap_or(RouteCallState {
-                            rate_limits: Map::new(&env),
-                            circuit_breaker: CircuitBreakerState {
-                                failure_count: 0,
-                                opened_at: 0,
-                                is_open: false,
-                                is_half_open: false,
-                            },
-                        });
-
-                    if route_call_state.circuit_breaker.is_half_open {
-                        route_call_state.circuit_breaker.is_half_open = false;
-                        route_call_state.circuit_breaker.is_open = true;
-                        route_call_state.circuit_breaker.opened_at = env.ledger().timestamp();
-                        route_call_state.circuit_breaker.failure_count = 1;
-                        env.events().publish(
-                            (Symbol::new(&env, "circuit_opened"),),
-                            (
-                                route.clone(),
-                                route_call_state.circuit_breaker.failure_count,
-                            ),
-                        );
-                    } else {
-                        route_call_state.circuit_breaker.failure_count += 1;
-
-                        if route_call_state.circuit_breaker.failure_count
-                            >= config.failure_threshold
-                        {
-                            route_call_state.circuit_breaker.is_open = true;
-                            route_call_state.circuit_breaker.opened_at = env.ledger().timestamp();
-                            env.events().publish(
-                                (Symbol::new(&env, "circuit_opened"),),
-                                (
-                                    route.clone(),
-                                    route_call_state.circuit_breaker.failure_count,
-                                ),
-                            );
-                        }
-                    }
-
-                    env.storage()
-                        .instance()
-                        .set(&DataKey::RouteCallState(route), &route_call_state);
-                }
-            }
-        } else {
-            if let Some(config) = env
-                .storage()
-                .instance()
-                .get::<DataKey, RouteConfig>(&DataKey::RouteConfig(route.clone()))
-            {
-                if config.failure_threshold > 0 {
-                    let mut route_call_state: RouteCallState = env
-                        .storage()
-                        .instance()
-                        .get(&DataKey::RouteCallState(route.clone()))
-                        .unwrap_or(RouteCallState {
-                            rate_limits: Map::new(&env),
-                            circuit_breaker: CircuitBreakerState {
-                                failure_count: 0,
-                                opened_at: 0,
-                                is_open: false,
-                                is_half_open: false,
-                            },
-                        });
-
-                    if route_call_state.circuit_breaker.is_half_open {
-                        route_call_state.circuit_breaker.is_half_open = false;
-                        route_call_state.circuit_breaker.failure_count = 0;
-                        route_call_state.circuit_breaker.opened_at = 0;
-                        env.events().publish(
-                            (Symbol::new(&env, router_common::EVENT_CIRCUIT_CLOSED),),
-                            route.clone(),
-                        );
-                    } else if !route_call_state.circuit_breaker.is_open
-                        && route_call_state.circuit_breaker.failure_count > 0
-                    {
-                        route_call_state.circuit_breaker.failure_count = 0;
-                    }
-
-                    env.storage()
-                        .instance()
-                        .set(&DataKey::RouteCallState(route), &route_call_state);
-                }
+                    .set(&DataKey::RouteCallState(route.clone()), &route_call_state);
             }
         }
     }
@@ -754,40 +595,11 @@ impl RouterMiddleware {
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, MiddlewareError)?;
 
-        if let Some(config) = env
-            .storage()
-            .instance()
-            .get::<DataKey, RouteConfig>(&DataKey::RouteConfig(route.clone()))
-        {
-            if config.log_retention > 0 {
-                let placeholder = CallLogEntry {
-                    caller: caller.clone(),
-                    timestamp: 0,
-                    success: false,
-                    route: route.clone(),
-                };
-                let mut entries = Vec::new(&env);
-                for _ in 0..config.log_retention {
-                    entries.push_back(placeholder.clone());
-                }
-                let log = CallLogState {
-                    entries,
-                    head: 0,
-                    count: 0,
-                };
-                env.storage()
-                    .instance()
-                    .set(&DataKey::CallLog(route.clone()), &log);
-            } else {
-                env.storage()
-                    .instance()
-                    .remove(&DataKey::CallLog(route.clone()));
-            }
-        } else {
-            env.storage()
-                .instance()
-                .remove(&DataKey::CallLog(route.clone()));
-        }
+        // Delegates to call_log::clear, which removes both the CallLog ring
+        // buffer *and* the CallLogSummary for the route (issue #812: previously
+        // this only cleared CallLog inline and left CallLogSummary stale).
+        call_log::clear(&env, &route);
+
         env.events()
             .publish((Symbol::new(&env, "call_log_cleared"),), route);
         Ok(())
@@ -895,24 +707,7 @@ impl RouterMiddleware {
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, MiddlewareError)?;
 
-        let mut route_call_state: RouteCallState = env
-            .storage()
-            .instance()
-            .get(&DataKey::RouteCallState(route.clone()))
-            .unwrap_or(RouteCallState {
-                rate_limits: Map::new(&env),
-                circuit_breaker: CircuitBreakerState {
-                    failure_count: 0,
-                    opened_at: 0,
-                    is_open: false,
-                    is_half_open: false,
-                },
-            });
-
-        route_call_state.rate_limits.remove(target_caller.clone());
-        env.storage()
-            .instance()
-            .set(&DataKey::RouteCallState(route), &route_call_state);
+        rate_limit::reset_for_caller(&env, &route, &target_caller);
 
         Ok(())
     }
@@ -983,29 +778,7 @@ impl RouterMiddleware {
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, MiddlewareError)?;
 
-        let reset_state = CircuitBreakerState {
-            failure_count: 0,
-            opened_at: 0,
-            is_open: false,
-            is_half_open: false,
-        };
-        let mut route_call_state: RouteCallState = env
-            .storage()
-            .instance()
-            .get(&DataKey::RouteCallState(route.clone()))
-            .unwrap_or(RouteCallState {
-                rate_limits: Map::new(&env),
-                circuit_breaker: CircuitBreakerState {
-                    failure_count: 0,
-                    opened_at: 0,
-                    is_open: false,
-                    is_half_open: false,
-                },
-            });
-        route_call_state.circuit_breaker = reset_state;
-        env.storage()
-            .instance()
-            .set(&DataKey::RouteCallState(route), &route_call_state);
+        circuit_breaker::reset(&env, &route);
         Ok(())
     }
 
@@ -1032,6 +805,13 @@ impl RouterMiddleware {
     ) -> Result<(), MiddlewareError> {
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, MiddlewareError)?;
+
+        // Issue #814: a zero-second window with a nonzero max_calls would grant
+        // the caller unlimited calls (the window never elapses in a way that
+        // caps them), mirroring the equivalent guard in configure_route.
+        if window_secs == 0 && max_calls > 0 {
+            return Err(MiddlewareError::InvalidConfig);
+        }
 
         let key = DataKey::CallerRateLimit(route.clone(), target_caller.clone());
         env.storage().instance().set(
@@ -2612,5 +2392,67 @@ mod tests {
             client.get_caller_rate_limit(&route, &caller).is_none(),
             "no override should return None"
         );
+    }
+
+    // ── Issue #812: reset_route_call_log must also clear CallLogSummary ─────
+
+    #[test]
+    fn test_reset_route_call_log_clears_summary() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &0, &0, &true, &0, &0, &5, &0);
+
+        let caller = Address::generate(&env);
+        client.pre_call(&caller, &route);
+        client.post_call(&caller, &route, &true);
+
+        assert!(client.get_call_log_summary(&route).is_some());
+        assert!(client.get_call_log_length(&route) > 0);
+
+        client.reset_route_call_log(&admin, &route);
+
+        assert!(
+            client.get_call_log_summary(&route).is_none(),
+            "CallLogSummary must be cleared by reset_route_call_log, not left stale"
+        );
+        assert_eq!(client.get_call_log_length(&route), 0);
+        assert_eq!(client.get_call_log(&route).len(), 0);
+    }
+
+    // ── Issue #814: caller rate limit config must reject window_secs == 0
+    // with a nonzero max_calls (would otherwise grant unlimited calls) ──────
+
+    #[test]
+    fn test_configure_caller_rate_limit_zero_window_with_max_calls_fails() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
+        let caller = Address::generate(&env);
+
+        let result = client.try_configure_caller_rate_limit(&admin, &route, &caller, &1, &0);
+        assert_eq!(result, Err(Ok(MiddlewareError::InvalidConfig)));
+    }
+
+    #[test]
+    fn test_set_caller_rate_limit_zero_window_with_max_calls_fails() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
+        let caller = Address::generate(&env);
+
+        let result = client.try_set_caller_rate_limit(&admin, &route, &caller, &1, &0);
+        assert_eq!(result, Err(Ok(MiddlewareError::InvalidConfig)));
+    }
+
+    #[test]
+    fn test_set_caller_rate_limit_zero_window_and_zero_max_is_unlimited_and_succeeds() {
+        // window_secs == 0 is only invalid when paired with a nonzero max_calls;
+        // 0/0 (unlimited) must still be accepted, mirroring configure_route.
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "oracle/get_price");
+        client.configure_route(&admin, &route, &5, &60, &true, &0, &0, &0, &0);
+        let caller = Address::generate(&env);
+
+        assert!(client.try_set_caller_rate_limit(&admin, &route, &caller, &0, &0).is_ok());
     }
 }

--- a/contracts/router-middleware/src/rate_limit.rs
+++ b/contracts/router-middleware/src/rate_limit.rs
@@ -1,75 +1,86 @@
 //! Per-caller rate limiting logic for router-middleware.
 //!
 //! Implements a fixed-window counter keyed by `(route, caller)`. The window
-//! resets on the first call after `window_seconds` has elapsed since
-//! `window_start`. Logic is called from [`pre_call`] in `lib.rs`.
+//! resets on the first call after `effective_window` seconds has elapsed
+//! since `window_start`. The limit/window a caller is actually checked
+//! against may come from the route-level default (`RouteConfig` plus
+//! `burst_allowance`) or from a per-caller `CallerRateLimitConfig` override —
+//! resolving which one applies is the caller's job (see [`crate::pre_call`]);
+//! this module only owns the window/counter arithmetic so it isn't
+//! duplicated between the route-level and per-caller-override paths.
 
 use soroban_sdk::{Address, Env, String};
 
-use crate::{DataKey, RateLimitState, RouteCallState, RouteConfig};
+use crate::{DataKey, RateLimitState, RouteCallState};
 
-/// Check and update the rate limit for `caller` on `route`.
+/// Outcome of checking a caller's rate limit state against an effective
+/// limit/window.
+pub struct RateLimitCheck {
+    /// `true` if the caller has exceeded `effective_limit` for the current window.
+    pub exceeded: bool,
+    /// The `RateLimitState` that should be stored for `caller` regardless of
+    /// whether the limit was exceeded (callers should still persist this to
+    /// track the rolling window / violation count).
+    pub updated_state: RateLimitState,
+}
+
+/// Check and compute the updated rate limit state for `caller` on a route,
+/// given the already-resolved `effective_limit` / `effective_window` (which
+/// may come from the route default or a per-caller override).
 ///
-/// Returns `true` if the rate limit is exceeded (call should be blocked).
+/// This function does not mutate or persist any storage itself — the caller
+/// is expected to apply `updated_state` to `route_call_state.rate_limits`
+/// and decide how to react to `exceeded` (reject / throttle / log-only) and
+/// when to persist the result.
 pub fn check_and_increment(
     env: &Env,
     caller: &Address,
-    route: &String,
-    config: &RouteConfig,
-    route_call_state: &mut RouteCallState,
-) -> bool {
-    if config.max_calls_per_window == 0 {
-        return false; // unlimited
-    }
-
+    route_call_state: &RouteCallState,
+    effective_limit: u32,
+    effective_window: u64,
+) -> RateLimitCheck {
     let now = env.ledger().timestamp();
-    let state: RateLimitState =
-        route_call_state
-            .rate_limits
-            .get(caller.clone())
-            .unwrap_or(RateLimitState {
-                calls_in_window: 0,
-                window_start: now,
-                total_violations: 0,
-            });
+    let state: RateLimitState = route_call_state
+        .rate_limits
+        .get(caller.clone())
+        .unwrap_or(RateLimitState {
+            calls_in_window: 0,
+            window_start: now,
+            total_violations: 0,
+        });
 
-    let window_elapsed = now >= state.window_start + config.window_seconds;
+    let window_elapsed = now >= state.window_start + effective_window;
     let calls = if window_elapsed {
         0
     } else {
         state.calls_in_window
     };
-    let window_start = if window_elapsed {
-        now
+    let window_start = if window_elapsed { now } else { state.window_start };
+
+    if calls >= effective_limit {
+        RateLimitCheck {
+            exceeded: true,
+            updated_state: RateLimitState {
+                calls_in_window: calls,
+                window_start,
+                total_violations: state.total_violations + 1,
+            },
+        }
     } else {
-        state.window_start
-    };
-
-    if calls >= config.max_calls_per_window + config.burst_allowance {
-        // Record violation without incrementing the call count
-        let mut violation_state = state.clone();
-        violation_state.total_violations = violation_state.total_violations.saturating_add(1);
-        route_call_state
-            .rate_limits
-            .set(caller.clone(), violation_state);
-        env.storage()
-            .instance()
-            .set(&DataKey::RouteCallState(route.clone()), route_call_state);
-        return true;
+        RateLimitCheck {
+            exceeded: false,
+            updated_state: RateLimitState {
+                calls_in_window: calls + 1,
+                window_start,
+                total_violations: state.total_violations,
+            },
+        }
     }
-
-    route_call_state.rate_limits.set(
-        caller.clone(),
-        RateLimitState {
-            calls_in_window: calls + 1,
-            window_start,
-            total_violations: state.total_violations,
-        },
-    );
-    false
 }
 
 /// Reset the rate limit state for a specific caller on a route.
+///
+/// No-op if the route has no `RouteCallState` yet.
 pub fn reset_for_caller(env: &Env, route: &String, caller: &Address) {
     if let Some(mut state) = env
         .storage()
@@ -80,5 +91,135 @@ pub fn reset_for_caller(env: &Env, route: &String, caller: &Address) {
         env.storage()
             .instance()
             .set(&DataKey::RouteCallState(route.clone()), &state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RouterMiddleware;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::Map;
+
+    fn env_with_contract() -> (Env, Address) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, RouterMiddleware);
+        (env, contract_id)
+    }
+
+    fn empty_state(env: &Env) -> RouteCallState {
+        RouteCallState {
+            rate_limits: Map::new(env),
+            circuit_breaker: crate::CircuitBreakerState {
+                failure_count: 0,
+                opened_at: 0,
+                is_open: false,
+                is_half_open: false,
+            },
+        }
+    }
+
+    #[test]
+    fn check_and_increment_allows_calls_under_limit() {
+        let (env, contract_id) = env_with_contract();
+        let caller = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            let state = empty_state(&env);
+            let check = check_and_increment(&env, &caller, &state, 3, 60);
+            assert!(!check.exceeded);
+            assert_eq!(check.updated_state.calls_in_window, 1);
+        });
+    }
+
+    #[test]
+    fn check_and_increment_blocks_and_records_violation_over_limit() {
+        let (env, contract_id) = env_with_contract();
+        let caller = Address::generate(&env);
+        env.ledger().set_timestamp(1000);
+        env.as_contract(&contract_id, || {
+            let mut state = empty_state(&env);
+            state.rate_limits.set(
+                caller.clone(),
+                RateLimitState {
+                    calls_in_window: 3,
+                    window_start: 1000,
+                    total_violations: 0,
+                },
+            );
+
+            let check = check_and_increment(&env, &caller, &state, 3, 60);
+            assert!(check.exceeded);
+            assert_eq!(check.updated_state.calls_in_window, 3);
+            assert_eq!(check.updated_state.total_violations, 1);
+        });
+    }
+
+    #[test]
+    fn check_and_increment_rolls_window_over_after_elapsed() {
+        let (env, contract_id) = env_with_contract();
+        let caller = Address::generate(&env);
+        env.ledger().set_timestamp(1000);
+        env.as_contract(&contract_id, || {
+            let mut state = empty_state(&env);
+            state.rate_limits.set(
+                caller.clone(),
+                RateLimitState {
+                    calls_in_window: 3,
+                    window_start: 1000,
+                    total_violations: 0,
+                },
+            );
+
+            env.ledger().set_timestamp(1060);
+            let check = check_and_increment(&env, &caller, &state, 3, 60);
+            assert!(!check.exceeded);
+            assert_eq!(check.updated_state.calls_in_window, 1);
+            assert_eq!(check.updated_state.window_start, 1060);
+        });
+    }
+
+    #[test]
+    fn reset_for_caller_removes_existing_entry() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        let caller = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            let mut state = empty_state(&env);
+            state.rate_limits.set(
+                caller.clone(),
+                RateLimitState {
+                    calls_in_window: 2,
+                    window_start: 0,
+                    total_violations: 0,
+                },
+            );
+            env.storage()
+                .instance()
+                .set(&DataKey::RouteCallState(route.clone()), &state);
+
+            reset_for_caller(&env, &route, &caller);
+
+            let after: RouteCallState = env
+                .storage()
+                .instance()
+                .get(&DataKey::RouteCallState(route.clone()))
+                .unwrap();
+            assert!(after.rate_limits.get(caller).is_none());
+        });
+    }
+
+    #[test]
+    fn reset_for_caller_is_noop_when_no_state_exists() {
+        let (env, contract_id) = env_with_contract();
+        let route = String::from_str(&env, "route");
+        let caller = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            reset_for_caller(&env, &route, &caller);
+            assert!(env
+                .storage()
+                .instance()
+                .get::<DataKey, RouteCallState>(&DataKey::RouteCallState(route.clone()))
+                .is_none());
+        });
     }
 }


### PR DESCRIPTION
Closes #811
Closes #812
Closes #813
Closes #814

- #811: Added success-path and retry-then-succeed tests for `RouterExecution::execute`, asserting `ExecutionResult`, `stats()`, `get_execution_history`, and event payloads.
- #812: `reset_route_call_log` now clears `CallLogSummary` in addition to `CallLog`.
- #813: Wired `pre_call`/`post_call`/reset functions to the previously-dead `call_log`, `circuit_breaker`, `rate_limit` modules, removing duplicated inline logic (also fixed a missing `circuit_closed` event/`opened_at` reset bug found in `circuit_breaker::handle_success` during the wiring).
- #814: `configure_caller_rate_limit`/`set_caller_rate_limit` now reject `window_secs == 0 && max_calls > 0` with `InvalidConfig`, mirroring `configure_route`'s existing guard.