### PR TITLE
fix(router-registry): return NotFound when deprecating unregistered name

### DIFF
--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -458,6 +458,9 @@ impl RouterRegistry {
         caller.require_auth();
         Self::require_admin(&env, &caller)?;
         let versions = Self::get_versions_list(&env, &name);
+        if versions.is_empty() {
+            return Err(RegistryError::NotFound);
+        }
         for v in versions.iter() {
             // Skip already-deprecated entries rather than aborting
             let _ = Self::deprecate_one(&env, name.clone(), v, reason.clone());
@@ -1614,6 +1617,14 @@ mod tests {
         let constraint = String::from_str(&env, ">=0");
         let result = client.get_latest_with_constraint(&name, &Some(constraint));
         assert_eq!(result.version, 1);
+    }
+
+    #[test]
+    fn test_deprecate_all_versions_not_found_for_unregistered_name() {
+        let (env, admin, client) = setup();
+        let name = String::from_str(&env, "never-registered");
+        let result = client.try_deprecate_all_versions(&admin, &name, &None::<String>);
+        assert_eq!(result, Err(Ok(RegistryError::NotFound)));
     }
 
     #[test]


### PR DESCRIPTION
deprecate_all_versions silently returned Ok(()) for names that were never registered, because get_versions_list returns an empty Vec for unknown names. This was inconsistent with get_latest and get_latest_with_constraint which both return NotFound for empty versions lists.

Add an early return of RegistryError::NotFound when versions.is_empty() in deprecate_all_versions, and add a test asserting that deprecating an unregistered name returns NotFound.

closes: #827 