### PR TITLE
feat(router-quote): add unset_route_fee to revert route to default fee

### DIFF
--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -205,6 +205,9 @@ pub const EVENT_INITIALIZED: &str = "initialized";
 /// Standard event topic for per-route fee configuration
 pub const EVENT_ROUTE_FEE_SET: &str = "route_fee_set";
 
+/// Standard event topic for removing a custom per-route fee (reverts to default)
+pub const EVENT_ROUTE_FEE_UNSET: &str = "route_fee_unset";
+
 /// Standard event topic for a quote being calculated
 pub const EVENT_QUOTE_CALCULATED: &str = "quote_calculated";
 

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -176,6 +176,42 @@ impl RouterQuote {
         Ok(())
     }
 
+    /// Remove the custom fee for a specific route, reverting it to the default fee.
+    ///
+    /// After this call, `get_route_fee` for this route returns the contract's
+    /// default fee. If no custom fee was set for this route, this is a no-op
+    /// (the route continues using the default fee). Caller must be the admin.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `caller` - The address initiating the call; must be the admin.
+    /// * `route` - The route name whose custom fee should be removed.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`QuoteError::Unauthorized`] — if caller is not the admin.
+    pub fn unset_route_fee(
+        env: Env,
+        caller: Address,
+        route: String,
+    ) -> Result<(), QuoteError> {
+        caller.require_auth();
+        Self::require_admin(&env, &caller)?;
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::RouteFee(route.clone()));
+
+        env.events().publish(
+            (Symbol::new(&env, router_common::EVENT_ROUTE_FEE_UNSET),),
+            route,
+        );
+
+        Ok(())
+    }
+
     /// Set tiered fees for a specific route.
     ///
     /// The tiers are sorted by `min_amount` ascending and are used to select


### PR DESCRIPTION
## Summary

- Add `unset_route_fee(env, caller, route)` to `router-quote` that removes a route's custom fee entry from storage, causing `get_route_fee` to fall back to the contract default
- Follows the same admin-auth guard pattern as `set_route_fee` (caller must be admin, `caller.require_auth()`)
- Emits a `route_fee_unset` event matching the pattern of other admin setters
- Adds `EVENT_ROUTE_FEE_UNSET = "route_fee_unset"` constant to `router-common`

## Test plan

- [ ] Call `set_route_fee` then `unset_route_fee`; confirm `get_route_fee` returns the default fee afterwards
- [ ] Confirm `unset_route_fee` on a route with no custom fee is a no-op (no panic)
- [ ] Confirm unauthorized caller is rejected with `QuoteError::Unauthorized`
- [ ] Confirm `route_fee_unset` event is emitted with the route name

Closes #800