### PR TITLE
fix(router-core): emit routed event with correct route name

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -839,7 +839,7 @@ impl RouterCore {
 
         env.events().publish(
             (Symbol::new(&env, router_common::EVENT_ROUTED),),
-            (name.clone(), entry.address.clone()),
+            (final_name.clone(), entry.address.clone()),
         );
 
         Ok(entry.address)


### PR DESCRIPTION
## Summary

- `resolve()` was emitting the `routed` event with the originally-requested `name` but the address of `final_name` (the alias-resolved or best-scored route), so the two fields in the event referred to different routes.
- Changed the event payload to use `final_name` so the route name and address are always consistent.

## Test plan
- [ ] Verify that after alias resolution, the `routed` event carries the canonical route name and its address
- [ ] Verify that when BestRoute selection kicks in, the event carries the best-scored route name and its address
- [ ] Verify that in the simple (no alias, no BestRoute) case, `final_name == resolved_name` and event is unchanged

Closes #792