### PR TITLE
fix(router-quote): validate FeeTier.min_amount is non-negative

### DIFF
--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -85,6 +85,8 @@ pub enum QuoteError {
     NoQuotesProvided = 6,
     RouteNotFound = 7,
     ArithmeticOverflow = 8,
+    /// A [`FeeTier`] has an invalid `min_amount` (e.g. negative).
+    InvalidFeeTier = 9,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -192,6 +194,9 @@ impl RouterQuote {
 
         let mut sorted_tiers: Vec<FeeTier> = Vec::new(&env);
         for tier in tiers.iter() {
+            if tier.min_amount < 0 {
+                return Err(QuoteError::InvalidFeeTier);
+            }
             if tier.fee_bps > 10000 {
                 return Err(QuoteError::InvalidFeeBps);
             }


### PR DESCRIPTION
## Summary

- `set_route_fee_tiers` accepted `FeeTier` structs with negative `min_amount` values, producing nonsensical tiered fee logic
- Add validation before inserting each tier: return `QuoteError::InvalidFeeTier` (new variant = 9) if `min_amount < 0`
- Negative thresholds can never match a valid `amount_in`, so rejecting them eagerly is correct

## Test plan

- [ ] Confirm `set_route_fee_tiers` with a tier where `min_amount = -1` returns `QuoteError::InvalidFeeTier`
- [ ] Confirm `set_route_fee_tiers` with all non-negative tiers continues to work
- [ ] Confirm `QuoteError::InvalidFeeTier = 9` does not collide with existing variants

Closes #801