### PR TITLE
fix(router-common): remove stray src/Cargo.toml that pins soroban-sdk 22

### DIFF
--- a/contracts/router-common/src/Cargo.toml
+++ b/contracts/router-common/src/Cargo.toml
@@ -1,7 +1,0 @@
-[package]
-name = "router-common"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-soroban-sdk = { version = "22", default-features = false }  # Match your other contracts' version


### PR DESCRIPTION
## Summary

- Delete `contracts/router-common/src/Cargo.toml`, a file that is not a valid Cargo workspace manifest location
- The real manifest is at `contracts/router-common/Cargo.toml` which correctly inherits `soroban-sdk = "21.7.6"` from the workspace
- The stray file pinned `soroban-sdk = "22"` causing a silent version divergence when any tooling resolved it

Closes #804