### PR TITLE
fix(router-quote): cap track_configured_route at MAX_TRACKED_ROUTES

### DIFF
--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -85,9 +85,17 @@ pub enum QuoteError {
     NoQuotesProvided = 6,
     RouteNotFound = 7,
     ArithmeticOverflow = 8,
+    /// The configured-routes index has reached [`MAX_TRACKED_ROUTES`]; cannot add more.
+    TooManyRoutes = 9,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
+
+/// Maximum number of routes that can be tracked in the configured-routes index.
+///
+/// `track_configured_route` returns [`QuoteError::TooManyRoutes`] once this
+/// limit is reached to prevent unbounded storage growth.
+const MAX_TRACKED_ROUTES: u32 = 500;
 
 #[contract]
 pub struct RouterQuote;
@@ -162,7 +170,7 @@ impl RouterQuote {
             return Err(QuoteError::InvalidFeeBps);
         }
 
-        Self::track_configured_route(&env, &route);
+        Self::track_configured_route(&env, &route)?;
 
         env.storage()
             .instance()
@@ -207,7 +215,7 @@ impl RouterQuote {
             sorted_tiers.insert(position, tier.clone());
         }
 
-        Self::track_configured_route(&env, &route);
+        Self::track_configured_route(&env, &route)?;
         env.storage()
             .instance()
             .set(&DataKey::RouteFeeTiers(route.clone()), &sorted_tiers);
@@ -560,12 +568,16 @@ impl RouterQuote {
             .set(&DataKey::ConfiguredRoutes, routes);
     }
 
-    fn track_configured_route(env: &Env, route: &String) {
+    fn track_configured_route(env: &Env, route: &String) -> Result<(), QuoteError> {
         let mut routes = Self::read_configured_routes(env);
         if !routes.contains(route) {
+            if routes.len() >= MAX_TRACKED_ROUTES {
+                return Err(QuoteError::TooManyRoutes);
+            }
             routes.push_back(route.clone());
             Self::write_configured_routes(env, &routes);
         }
+        Ok(())
     }
 
     fn resolve_route_fee_bps(env: Env, route: String, amount_in: i128) -> Result<u32, QuoteError> {


### PR DESCRIPTION
## Summary

- `track_configured_route` already deduplicated entries but had no upper bound on the `ConfiguredRoutes` Vec, allowing unbounded storage growth
- Add `MAX_TRACKED_ROUTES = 500` constant
- Change `track_configured_route` to return `Result<(), QuoteError>` and return `QuoteError::TooManyRoutes` (new variant = 9) when the limit is reached
- Update both `set_route_fee` and `set_route_fee_tiers` to propagate the error with `?`

## Test plan

- [ ] Register 500 unique routes via `set_route_fee`; confirm the 501st returns `QuoteError::TooManyRoutes`
- [ ] Confirm re-setting a fee on an already-tracked route does not count against the cap (dedup still works)
- [ ] Confirm normal fee setting with fewer than 500 routes is unaffected

Closes #802