### PR TITLE
fix(router-core): require admin auth in initialize()

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -213,6 +213,7 @@ impl RouterCore {
     /// # Errors
     /// * [`RouterError::AlreadyInitialized`] — if the contract has already been initialized.
     pub fn initialize(env: Env, admin: Address) -> Result<(), RouterError> {
+        admin.require_auth();
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(RouterError::AlreadyInitialized);
         }


### PR DESCRIPTION
## Summary

- `initialize()` in `router-core` accepted any caller, allowing a front-running attack where an attacker calls it before the deployer and sets themselves as admin
- Add `admin.require_auth()` at the top of `initialize()` so the provided admin address must sign the transaction
- The existing `AlreadyInitialized` guard already prevents double-initialization; this change adds the missing authorization check for the first call

## Test plan

- [ ] Confirm that `initialize(admin)` succeeds when the transaction is signed by `admin`
- [ ] Confirm that `initialize(admin)` fails (auth error) when the transaction is NOT signed by `admin`
- [ ] Confirm that calling `initialize` a second time still returns `RouterError::AlreadyInitialized`

Closes #803