### PR TITLE
fix(contracts): replace hand-rolled require_admin helpers with require_admin_simple! macro

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -241,7 +241,7 @@ impl RouterAccess {
         admin: Address,
     ) -> Result<(), AccessError> {
         caller.require_auth();
-        Self::require_super_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::SuperAdmin, AccessError)?;
         if Self::is_blacklisted_internal(&env, &admin) {
             return Err(AccessError::Blacklisted);
         }
@@ -272,7 +272,7 @@ impl RouterAccess {
         parent_role: String,
     ) -> Result<(), AccessError> {
         caller.require_auth();
-        Self::require_super_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::SuperAdmin, AccessError)?;
         Self::ensure_no_role_parent_cycle(&env, &role, &parent_role)?;
 
         Self::track_role_in_all_roles(&env, &role);
@@ -318,7 +318,7 @@ impl RouterAccess {
     /// Blacklist an address.
     pub fn blacklist(env: Env, caller: Address, target: Address) -> Result<(), AccessError> {
         caller.require_auth();
-        Self::require_super_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::SuperAdmin, AccessError)?;
 
         let super_admin: Address = env
             .storage()
@@ -349,7 +349,7 @@ impl RouterAccess {
     /// Remove from blacklist.
     pub fn unblacklist(env: Env, caller: Address, target: Address) -> Result<(), AccessError> {
         caller.require_auth();
-        Self::require_super_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::SuperAdmin, AccessError)?;
         env.storage()
             .instance()
             .remove(&DataKey::Blacklisted(target.clone()));
@@ -589,7 +589,7 @@ impl RouterAccess {
         new_admin: Address,
     ) -> Result<(), AccessError> {
         current.require_auth();
-        Self::require_super_admin(&env, &current)?;
+        router_common::require_admin_simple!(&env, &current, &DataKey::SuperAdmin, AccessError)?;
         env.storage()
             .instance()
             .set(&DataKey::SuperAdmin, &new_admin);
@@ -614,7 +614,7 @@ impl RouterAccess {
         target: Address,
     ) -> Result<(), AccessError> {
         caller.require_auth();
-        Self::require_super_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::SuperAdmin, AccessError)?;
         env.storage()
             .instance()
             .remove(&DataKey::RoleExpiry(role.clone(), target.clone()));
@@ -783,17 +783,7 @@ impl RouterAccess {
         Ok(())
     }
 
-    fn require_super_admin(env: &Env, caller: &Address) -> Result<(), AccessError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::SuperAdmin)
-            .ok_or(AccessError::NotInitialized)?;
-        if &admin != caller {
-            return Err(AccessError::Unauthorized);
-        }
-        Ok(())
-    }
+
 
     fn require_role_manager(env: &Env, caller: &Address, role: &String) -> Result<(), AccessError> {
         if Self::is_blacklisted_internal(env, caller) {

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -156,7 +156,7 @@ impl RouterQuote {
         fee_bps: u32,
     ) -> Result<(), QuoteError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, QuoteError)?;
 
         if fee_bps > 10000 {
             return Err(QuoteError::InvalidFeeBps);
@@ -188,7 +188,7 @@ impl RouterQuote {
         tiers: Vec<FeeTier>,
     ) -> Result<(), QuoteError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, QuoteError)?;
 
         let mut sorted_tiers: Vec<FeeTier> = Vec::new(&env);
         for tier in tiers.iter() {
@@ -453,7 +453,7 @@ impl RouterQuote {
     /// * [`QuoteError::InvalidFeeBps`] — if fee_bps > 10000.
     pub fn set_default_fee(env: Env, caller: Address, fee_bps: u32) -> Result<(), QuoteError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, QuoteError)?;
 
         if fee_bps > 10000 {
             return Err(QuoteError::InvalidFeeBps);
@@ -526,7 +526,7 @@ impl RouterQuote {
         new_admin: Address,
     ) -> Result<(), QuoteError> {
         current.require_auth();
-        Self::require_admin(&env, &current)?;
+        router_common::require_admin_simple!(&env, &current, &DataKey::Admin, QuoteError)?;
         env.storage().instance().set(&DataKey::Admin, &new_admin);
 
         env.events().publish(
@@ -539,13 +539,7 @@ impl RouterQuote {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn require_admin(env: &Env, caller: &Address) -> Result<(), QuoteError> {
-        let admin = Self::admin(env.clone())?;
-        if &admin != caller {
-            return Err(QuoteError::Unauthorized);
-        }
-        Ok(())
-    }
+
 
     fn read_configured_routes(env: &Env) -> Vec<String> {
         env.storage()

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -135,7 +135,7 @@ impl RouterRegistry {
         version: u32,
     ) -> Result<(), RegistryError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RegistryError)?;
         Self::register_entry(&env, &caller, name, address, version)
     }
 
@@ -197,7 +197,7 @@ impl RouterRegistry {
         health_fn: Option<Symbol>,
     ) -> Result<(), RegistryError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RegistryError)?;
 
         if let Some(fn_sym) = health_fn {
             // SECURITY (issue #828): `try_invoke_contract` is a real
@@ -231,7 +231,7 @@ impl RouterRegistry {
         fail_fast: bool,
     ) -> Result<router_common::BatchResult, RegistryError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RegistryError)?;
         let mut result = router_common::BatchResult::new(&env);
 
         if fail_fast {
@@ -442,7 +442,7 @@ impl RouterRegistry {
         reason: Option<String>,
     ) -> Result<(), RegistryError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RegistryError)?;
         Self::deprecate_one(&env, name, version, reason)
     }
 
@@ -456,7 +456,7 @@ impl RouterRegistry {
         reason: Option<String>,
     ) -> Result<(), RegistryError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RegistryError)?;
         let versions = Self::get_versions_list(&env, &name);
         if versions.is_empty() {
             return Err(RegistryError::NotFound);
@@ -503,7 +503,7 @@ impl RouterRegistry {
         fail_fast: bool,
     ) -> Result<router_common::BatchResult, RegistryError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RegistryError)?;
         let mut result = router_common::BatchResult::new(&env);
         for (index, (name, version)) in entries.iter().enumerate() {
             let idx = index as u32;
@@ -542,7 +542,7 @@ impl RouterRegistry {
         new_admin: Address,
     ) -> Result<(), RegistryError> {
         current.require_auth();
-        Self::require_admin(&env, &current)?;
+        router_common::require_admin_simple!(&env, &current, &DataKey::Admin, RegistryError)?;
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         env.events().publish(
             (Symbol::new(&env, router_common::EVENT_ADMIN_TRANSFERRED),),
@@ -765,13 +765,7 @@ impl RouterRegistry {
         *fn_sym == Symbol::new(env, "health") || *fn_sym == Symbol::new(env, "ping")
     }
 
-    fn require_admin(env: &Env, caller: &Address) -> Result<(), RegistryError> {
-        let admin = Self::admin(env.clone())?;
-        if &admin != caller {
-            return Err(RegistryError::Unauthorized);
-        }
-        Ok(())
-    }
+
 
     fn get_versions_list(env: &Env, name: &String) -> Vec<u32> {
         env.storage()

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -129,7 +129,7 @@ impl RouterTimelock {
         deps: Vec<Bytes>,
     ) -> Result<Bytes, TimelockError> {
         proposer.require_auth();
-        Self::require_admin(&env, &proposer)?;
+        router_common::require_admin_simple!(&env, &proposer, &DataKey::Admin, TimelockError)?;
 
         let min_delay: u64 = env
             .storage()
@@ -208,7 +208,7 @@ impl RouterTimelock {
     /// Cancel a queued operation before it is executed.
     pub fn cancel(env: Env, caller: Address, op_id: Bytes) -> Result<(), TimelockError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, TimelockError)?;
 
         let mut op: Op = env
             .storage()
@@ -239,7 +239,7 @@ impl RouterTimelock {
     /// Returns `TimelockError::Expired` if called after `eta + grace_period_seconds`.
     pub fn execute(env: Env, caller: Address, op_id: Bytes) -> Result<(), TimelockError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, TimelockError)?;
 
         let mut op: Op = env
             .storage()
@@ -290,7 +290,7 @@ impl RouterTimelock {
         new_description: String,
     ) -> Result<(), TimelockError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, TimelockError)?;
 
         let mut op: Op = env
             .storage()
@@ -561,7 +561,7 @@ impl RouterTimelock {
         new_min_delay: u64,
     ) -> Result<(), TimelockError> {
         caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, TimelockError)?;
 
         let old_min_delay: u64 = env
             .storage()
@@ -599,7 +599,7 @@ impl RouterTimelock {
         new_admin: Address,
     ) -> Result<(), TimelockError> {
         current.require_auth();
-        Self::require_admin(&env, &current)?;
+        router_common::require_admin_simple!(&env, &current, &DataKey::Admin, TimelockError)?;
 
         env.storage().instance().set(&DataKey::Admin, &new_admin);
 
@@ -613,17 +613,7 @@ impl RouterTimelock {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn require_admin(env: &Env, caller: &Address) -> Result<(), TimelockError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(TimelockError::NotInitialized)?;
-        if &admin != caller {
-            return Err(TimelockError::Unauthorized);
-        }
-        Ok(())
-    }
+
 
     fn require_op_pending(op: &Op) -> Result<(), TimelockError> {
         if op.cancelled {


### PR DESCRIPTION
## Summary

- Remove private `require_admin` / `require_super_admin` helper functions from `router-registry`, `router-quote`, `router-access`, and `router-timelock`
- Replace each call site with `router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, ErrorType)?;`
- `router-access` uses `DataKey::SuperAdmin`; the other three use `DataKey::Admin`
- All four error types already have `NotInitialized` and `Unauthorized` variants required by the macro
- Admin validation logic is now maintained in one place in `router-common`

Closes #805