### PR TITLE
fix(router-core): guard extend_route_ttl against zero-ledger extension

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -180,6 +180,7 @@ pub enum RouterError {
     InvalidAddress = 12,
     RouteExpired = 13,
     InvalidScore = 14,
+    InvalidTtlExtension = 15,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -414,6 +415,10 @@ impl RouterCore {
     ) -> Result<(), RouterError> {
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
+
+        if additional_ledgers == 0 {
+            return Err(RouterError::InvalidTtlExtension);
+        }
 
         let mut entry: RouteEntry = env
             .storage()


### PR DESCRIPTION
## Summary

- `extend_route_ttl(name, 0)` silently converted a permanent route (`expires_at: None`) into one that expired at the current ledger sequence: the base defaulted to `env.ledger().sequence()` and adding `0` left the TTL at the current slot, so the route expired on the very next ledger.
- Added a guard at the top of `extend_route_ttl`: if `additional_ledgers == 0`, return `RouterError::InvalidTtlExtension` (new variant 15) before any storage access.

## Test plan
- [ ] Verify `extend_route_ttl(name, 0)` returns `Err(InvalidTtlExtension)` for a permanent route
- [ ] Verify `extend_route_ttl(name, 0)` returns `Err(InvalidTtlExtension)` for a route with an existing TTL
- [ ] Verify `extend_route_ttl(name, N)` for N > 0 still works correctly

Closes #793