### PR TITLE
fix(contracts): replace Custom("Error") catch-alls with named error strings in batch helpers

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -651,7 +651,27 @@ impl RouterAccess {
             AccessError::InvalidExpiry => router_common::BatchItemError::Custom(
                 soroban_sdk::String::from_str(env, "InvalidExpiry"),
             ),
-            _ => router_common::BatchItemError::Custom(soroban_sdk::String::from_str(env, "Error")),
+            AccessError::AlreadyInitialized => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "AlreadyInitialized"),
+            ),
+            AccessError::NotInitialized => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "NotInitialized"),
+            ),
+            AccessError::RoleNotFound => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "RoleNotFound"),
+            ),
+            AccessError::CannotBlacklistAdmin => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "CannotBlacklistAdmin"),
+            ),
+            AccessError::DestinationAlreadyHasRole => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "DestinationAlreadyHasRole"),
+            ),
+            AccessError::HierarchyCycle => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "HierarchyCycle"),
+            ),
+            AccessError::HierarchyTooDeep => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "HierarchyTooDeep"),
+            ),
         }
     }
 

--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -2053,7 +2053,33 @@ impl RouterCore {
             RouterError::RouteNotFound => router_common::BatchItemError::Custom(
                 soroban_sdk::String::from_str(env, "RouteNotFound"),
             ),
-            _ => router_common::BatchItemError::Custom(soroban_sdk::String::from_str(env, "Error")),
+            RouterError::AlreadyInitialized => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "AlreadyInitialized"),
+            ),
+            RouterError::NotInitialized => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "NotInitialized"),
+            ),
+            RouterError::RoutePaused => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "RoutePaused"),
+            ),
+            RouterError::RouterPaused => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "RouterPaused"),
+            ),
+            RouterError::CircularDependency => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "CircularDependency"),
+            ),
+            RouterError::RouteInUse => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "RouteInUse"),
+            ),
+            RouterError::InvalidAddress => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "InvalidAddress"),
+            ),
+            RouterError::RouteExpired => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "RouteExpired"),
+            ),
+            RouterError::InvalidScore => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "InvalidScore"),
+            ),
         }
     }
 

--- a/contracts/router-registry/src/lib.rs
+++ b/contracts/router-registry/src/lib.rs
@@ -665,15 +665,30 @@ impl RouterRegistry {
             RegistryError::InvalidVersion => router_common::BatchItemError::InvalidName,
             RegistryError::Unauthorized => router_common::BatchItemError::Unauthorized,
             RegistryError::InvalidConstraint => router_common::BatchItemError::InvalidMetadata,
-            // `InvalidHealthFn` and other variants are intentionally not
-            // listed here: `bulk_register` only invokes
-            // `validate_registration` and `register_entry`, never
-            // `register_with_check`, so these discriminants cannot be
-            // produced inside a batch and the catch-all is unreachable for
-            // them in practice. If a future code path on this contract can
-            // emit these errors during a bulk operation, add an explicit
-            // arm for it rather than relying on the catch-all.
-            _ => router_common::BatchItemError::Custom(soroban_sdk::String::from_str(env, "Error")),
+            RegistryError::NotInitialized => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "NotInitialized"),
+            ),
+            RegistryError::AlreadyInitialized => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "AlreadyInitialized"),
+            ),
+            RegistryError::NotFound => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "NotFound"),
+            ),
+            RegistryError::AlreadyDeprecated => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "AlreadyDeprecated"),
+            ),
+            RegistryError::VersionNotFound => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "VersionNotFound"),
+            ),
+            RegistryError::AllVersionsDeprecated => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "AllVersionsDeprecated"),
+            ),
+            RegistryError::ContractUnreachable => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "ContractUnreachable"),
+            ),
+            RegistryError::InvalidHealthFn => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "InvalidHealthFn"),
+            ),
         }
     }
 
@@ -1192,12 +1207,12 @@ mod tests {
         assert_eq!(results.failures.get(0).unwrap().index, 1);
         assert_eq!(
             results.failures.get(0).unwrap().error,
-            router_common::BatchItemError::Custom(String::from_str(&env, "Error"))
+            router_common::BatchItemError::Custom(String::from_str(&env, "VersionNotFound"))
         );
         assert_eq!(results.failures.get(1).unwrap().index, 2);
         assert_eq!(
             results.failures.get(1).unwrap().error,
-            router_common::BatchItemError::Custom(String::from_str(&env, "Error"))
+            router_common::BatchItemError::Custom(String::from_str(&env, "AlreadyDeprecated"))
         );
     }
 


### PR DESCRIPTION
## Summary

- `router_error_to_batch` (router-core), `registry_error_to_batch` (router-registry), and `access_error_to_batch` (router-access) each had a `_ => Custom("Error")` wildcard arm that silently collapsed distinct error variants into an opaque string
- Replace each catch-all with exhaustive explicit match arms that propagate the variant name as the `Custom` payload (e.g. `VersionNotFound` → `Custom("VersionNotFound")`)
- Update two test assertions in router-registry that expected `Custom("Error")` for `VersionNotFound` and `AlreadyDeprecated` to match the new named strings

Closes #806