### PR TITLE
fix(router-core): bound dependency resolver recursion to prevent stack exhaustion

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -180,7 +180,11 @@ pub enum RouterError {
     InvalidAddress = 12,
     RouteExpired = 13,
     InvalidScore = 14,
+    RecursionLimitExceeded = 15,
 }
+
+/// Maximum allowed recursion depth for dependency resolution.
+const MAX_RECURSION_DEPTH: u32 = 10;
 
 // ── Contract ──────────────────────────────────────────────────────────────────
 
@@ -1027,6 +1031,7 @@ impl RouterCore {
             &mut active_stack,
             &mut resolved_names,
             &mut resolved,
+            0,
         )?;
 
         Ok(resolved)
@@ -1855,7 +1860,12 @@ impl RouterCore {
         active_stack: &mut Vec<String>,
         resolved_names: &mut Vec<String>,
         resolved: &mut Vec<(String, Address)>,
+        depth: u32,
     ) -> Result<(), RouterError> {
+        if depth > MAX_RECURSION_DEPTH {
+            return Err(RouterError::RecursionLimitExceeded);
+        }
+
         for existing in active_stack.iter() {
             if existing == *name {
                 return Err(RouterError::CircularDependency);
@@ -1883,6 +1893,7 @@ impl RouterCore {
                 active_stack,
                 resolved_names,
                 resolved,
+                depth + 1,
             )?;
         }
 
@@ -1908,7 +1919,7 @@ impl RouterCore {
         depends_on: &String,
     ) -> Result<(), RouterError> {
         let mut stack = Vec::new(env);
-        Self::visit_dependencies(env, depends_on, route, &mut stack)
+        Self::visit_dependencies(env, depends_on, route, &mut stack, 0)
     }
 
     fn visit_dependencies(
@@ -1916,7 +1927,12 @@ impl RouterCore {
         current: &String,
         target: &String,
         stack: &mut Vec<String>,
+        depth: u32,
     ) -> Result<(), RouterError> {
+        if depth > MAX_RECURSION_DEPTH {
+            return Err(RouterError::RecursionLimitExceeded);
+        }
+
         for existing in stack.iter() {
             if existing == *current {
                 return Err(RouterError::CircularDependency);
@@ -1930,7 +1946,7 @@ impl RouterCore {
         stack.push_back(current.clone());
         let dependencies = Self::get_dependencies_for_route(env, current.clone());
         for dependency in dependencies.iter() {
-            Self::visit_dependencies(env, &dependency, target, stack)?;
+            Self::visit_dependencies(env, &dependency, target, stack, depth + 1)?;
         }
         stack.pop_back();
 


### PR DESCRIPTION
## Summary

- `resolve_dependencies_recursive` and `visit_dependencies` called themselves without any depth limit. A sufficiently deep (but cycle-free) dependency chain or deliberately crafted graph could exhaust the Soroban execution stack.
- Added a `MAX_RECURSION_DEPTH` constant (value: 10) and a `depth: u32` parameter to both private recursive helpers.
- Each recursive call passes `depth + 1`; when `depth > MAX_RECURSION_DEPTH`, the new `RecursionLimitExceeded` error (variant 15) is returned immediately.
- Public entry points (`resolve_with_dependencies`, `validate_dependency_cycle`) pass `0` as the initial depth.

## Test plan
- [ ] Verify that a dependency chain of depth 11 returns `Err(RecursionLimitExceeded)`
- [ ] Verify that a dependency chain of depth 10 resolves successfully
- [ ] Verify that existing cycle detection still works (returns `Err(CircularDependency)` before depth limit)

Closes #794