### PR TITLE
fix(router-multicall): skip store_results writes when simulate=true

### DIFF
--- a/contracts/router-multicall/src/lib.rs
+++ b/contracts/router-multicall/src/lib.rs
@@ -270,7 +270,7 @@ impl RouterMulticall {
                 result.record_failure(call_index, failure_error);
             }
 
-            if store_results {
+            if store_results && !simulate {
                 env.storage().instance().set(
                     &DataKey::BatchResult(batch_id, call_index),
                     &router_common::CallResult {


### PR DESCRIPTION
## Summary

- `execute_batch` already skips incrementing the `TotalBatches` counter when `simulate=true`, but it was not skipping the `store_results` storage writes. This meant dry-run calls with `store_results=true` mutated storage unconditionally, defeating the simulation guarantee.
- Changed `if store_results {` to `if store_results && !simulate {` so that batch-result storage is only written during real (non-simulate) execution.

## Test plan
- [ ] Verify `execute_batch(simulate=true, store_results=true)` does not write any `BatchResult` entries to storage
- [ ] Verify `execute_batch(simulate=false, store_results=true)` still writes `BatchResult` entries as before
- [ ] Verify `execute_batch(simulate=true, store_results=false)` is unaffected

Closes #795