### PR TITLE
fix(router-quote): emit route_fee_tiers_set event from set_route_fee_tiers

### DIFF
--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -205,6 +205,9 @@ pub const EVENT_INITIALIZED: &str = "initialized";
 /// Standard event topic for per-route fee configuration
 pub const EVENT_ROUTE_FEE_SET: &str = "route_fee_set";
 
+/// Standard event topic for per-route tiered fee schedule updates
+pub const EVENT_ROUTE_FEE_TIERS_SET: &str = "route_fee_tiers_set";
+
 /// Standard event topic for a quote being calculated
 pub const EVENT_QUOTE_CALCULATED: &str = "quote_calculated";
 

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -212,6 +212,11 @@ impl RouterQuote {
             .instance()
             .set(&DataKey::RouteFeeTiers(route.clone()), &sorted_tiers);
 
+        env.events().publish(
+            (Symbol::new(&env, router_common::EVENT_ROUTE_FEE_TIERS_SET),),
+            (route, sorted_tiers),
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Adds `EVENT_ROUTE_FEE_TIERS_SET = "route_fee_tiers_set"` constant to `router-common`
- Publishes the event at the end of `set_route_fee_tiers` in `router-quote`, matching the pattern of the sibling `set_route_fee` function

Closes #799