### PR TITLE
fix(router-multicall): prune old batch results after MAX_STORED_BATCHES=50

### DIFF
--- a/contracts/router-multicall/src/lib.rs
+++ b/contracts/router-multicall/src/lib.rs
@@ -32,6 +32,15 @@ pub enum DataKey {
     BatchResult(u64, u32), // (batch_id, call_index) -> CallResult
 }
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Maximum number of batch results to keep in instance storage.
+///
+/// When `store_results` is `true` and the total batch count exceeds this
+/// threshold, results from the oldest batch (`batch_id - MAX_STORED_BATCHES`)
+/// are removed to prevent unbounded ledger growth.
+const MAX_STORED_BATCHES: u64 = 50;
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /// A single call descriptor in a batch.
@@ -305,9 +314,20 @@ impl RouterMulticall {
         }
 
         if !simulate {
+            let new_batch_id = batch_id + 1;
             env.storage()
                 .instance()
-                .set(&DataKey::TotalBatches, &(batch_id + 1));
+                .set(&DataKey::TotalBatches, &new_batch_id);
+
+            // Prune stale batch results to prevent unbounded ledger growth.
+            if store_results && new_batch_id > MAX_STORED_BATCHES {
+                let stale_id = new_batch_id - MAX_STORED_BATCHES - 1;
+                for i in 0..max {
+                    env.storage()
+                        .instance()
+                        .remove(&DataKey::BatchResult(stale_id, i));
+                }
+            }
         }
 
         env.storage().instance().remove(&DataKey::Executing);


### PR DESCRIPTION
## Summary

- Adds `const MAX_STORED_BATCHES: u64 = 50` constant
- After each non-simulated batch execution, removes all `BatchResult` ledger entries for the batch that falls outside the window (`new_batch_id - MAX_STORED_BATCHES - 1`)
- Prevents unbounded accumulation of call results in instance storage

Closes #797