### PR TITLE
fix(router-core): extend instance storage TTL on every public entry point

### DIFF
--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -182,6 +182,16 @@ pub enum RouterError {
     InvalidScore = 14,
 }
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Minimum remaining TTL (in ledgers) before instance storage is extended.
+/// ~30 days at 5 s/ledger.
+const INSTANCE_TTL_THRESHOLD: u32 = 17280 * 30;
+
+/// Target TTL (in ledgers) applied to instance storage on every entry point.
+/// ~60 days at 5 s/ledger.
+const INSTANCE_TTL_EXTEND_TO: u32 = 17280 * 60;
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 /// Returns `true` if `entry` has a TTL set and the current ledger sequence
@@ -213,6 +223,7 @@ impl RouterCore {
     /// # Errors
     /// * [`RouterError::AlreadyInitialized`] — if the contract has already been initialized.
     pub fn initialize(env: Env, admin: Address) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(RouterError::AlreadyInitialized);
         }
@@ -254,6 +265,7 @@ impl RouterCore {
         address: Address,
         metadata: Option<RouteMetadata>,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -351,6 +363,7 @@ impl RouterCore {
         address: Address,
         ttl_ledgers: Option<u32>,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -379,6 +392,7 @@ impl RouterCore {
     /// # Returns
     /// `Some(expiry_ledger)` if the route has a TTL, `None` otherwise.
     pub fn get_route_expiry(env: Env, name: String) -> Option<u32> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage()
             .instance()
             .get::<DataKey, RouteEntry>(&DataKey::Route(name))
@@ -412,6 +426,7 @@ impl RouterCore {
         name: String,
         additional_ledgers: u32,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -469,6 +484,7 @@ impl RouterCore {
         name: String,
         new_address: Address,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -516,6 +532,7 @@ impl RouterCore {
     /// * [`RouterError::RouteNotFound`] — if no route with `name` exists.
     /// * [`RouterError::NotInitialized`] — if the contract has not been initialized.
     pub fn remove_route(env: Env, caller: Address, name: String) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -603,6 +620,7 @@ impl RouterCore {
         routes: Vec<RouteRegisterInput>,
         fail_fast: bool,
     ) -> Result<router_common::BatchResult, RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -688,6 +706,7 @@ impl RouterCore {
         names: Vec<String>,
         fail_fast: bool,
     ) -> Result<router_common::BatchResult, RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -750,6 +769,7 @@ impl RouterCore {
     /// * [`RouterError::RoutePaused`] — if the specific route is paused.
     /// * [`RouterError::RouteExpired`] — if the route's TTL has lapsed.
     pub fn resolve(env: Env, name: String) -> Result<Address, RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let paused: bool = env
             .storage()
             .instance()
@@ -869,6 +889,7 @@ impl RouterCore {
         name: String,
         paused: bool,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -913,6 +934,7 @@ impl RouterCore {
     /// * [`RouterError::Unauthorized`] — if `caller` is not the admin.
     /// * [`RouterError::NotInitialized`] — if the contract has not been initialized.
     pub fn set_paused(env: Env, caller: Address, paused: bool) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
         env.storage().instance().set(&DataKey::Paused, &paused);
@@ -937,6 +959,7 @@ impl RouterCore {
     /// # Returns
     /// `Some(`[`RouteEntry`]`)` if the route exists, `None` otherwise.
     pub fn get_route(env: Env, name: String) -> Option<RouteEntry> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage().instance().get(&DataKey::Route(name))
     }
 
@@ -951,6 +974,7 @@ impl RouterCore {
         route: String,
         depends_on: String,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -993,6 +1017,7 @@ impl RouterCore {
 
     /// Return the direct dependencies for a route.
     pub fn get_route_dependencies(env: Env, route: String) -> Result<Vec<String>, RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         if !env.storage().instance().has(&DataKey::Route(route.clone())) {
             return Err(RouterError::RouteNotFound);
         }
@@ -1005,6 +1030,7 @@ impl RouterCore {
         env: Env,
         name: String,
     ) -> Result<Vec<(String, Address)>, RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let paused: bool = env
             .storage()
             .instance()
@@ -1055,6 +1081,7 @@ impl RouterCore {
         name: String,
         metadata: Option<RouteMetadata>,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -1103,6 +1130,7 @@ impl RouterCore {
     /// # Returns
     /// `Some(`[`RouteMetadata`]`)` if metadata exists, `None` otherwise.
     pub fn get_metadata(env: Env, name: String) -> Option<RouteMetadata> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage()
             .instance()
             .get::<DataKey, RouteMetadata>(&DataKey::Metadata(name))
@@ -1113,6 +1141,7 @@ impl RouterCore {
     /// This read-only lookup scans registered route metadata and returns the
     /// names of routes tagged with `tag`. Routes without metadata are skipped.
     pub fn get_routes_by_tag(env: Env, tag: String) -> Vec<String> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let mut routes = Vec::new(&env);
 
         for name in Self::get_route_names(&env).iter() {
@@ -1141,6 +1170,7 @@ impl RouterCore {
         name: String,
         tag: String,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -1184,6 +1214,7 @@ impl RouterCore {
         name: String,
         tag: String,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -1225,6 +1256,7 @@ impl RouterCore {
 
     /// Return every unique tag currently used by route metadata.
     pub fn get_all_tags(env: Env) -> Vec<String> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let mut tags = Vec::new(&env);
 
         for name in Self::get_route_names(&env).iter() {
@@ -1263,6 +1295,7 @@ impl RouterCore {
     /// # Returns
     /// The total number of times a route has been resolved.
     pub fn total_routed(env: Env) -> u64 {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage()
             .instance()
             .get(&DataKey::TotalRouted)
@@ -1279,6 +1312,7 @@ impl RouterCore {
     /// # Returns
     /// The total number of registered routes.
     pub fn route_count(env: Env) -> u32 {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage()
             .instance()
             .get(&DataKey::RouteCount)
@@ -1310,6 +1344,7 @@ impl RouterCore {
         existing_name: String,
         alias_name: String,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -1355,6 +1390,7 @@ impl RouterCore {
     /// * [`RouterError::Unauthorized`] — if `caller` is not the admin.
     /// * [`RouterError::RouteNotFound`] — if `alias_name` does not exist.
     pub fn remove_alias(env: Env, caller: Address, alias_name: String) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -1403,6 +1439,7 @@ impl RouterCore {
     /// # Errors
     /// * [`RouterError::NotInitialized`] — if the contract has not been initialized.
     pub fn admin(env: Env) -> Result<Address, RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage()
             .instance()
             .get(&DataKey::Admin)
@@ -1430,6 +1467,7 @@ impl RouterCore {
         current: Address,
         new_admin: Address,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         current.require_auth();
         router_common::require_admin_simple!(&env, &current, &DataKey::Admin, RouterError)?;
         router_common::admin_transfer_complete!(&env, &current, &new_admin, &DataKey::Admin);
@@ -1447,6 +1485,7 @@ impl RouterCore {
     /// # Returns
     /// A `Vec<String>` containing all registered, non-expired route names.
     pub fn get_all_routes(env: Env) -> Vec<String> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let mut routes = Vec::new(&env);
         for name in Self::get_route_names(&env).iter() {
             let expired = env
@@ -1475,6 +1514,7 @@ impl RouterCore {
     /// A [`RouterStats`] snapshot with counts for total, active, paused,
     /// expired, aliased, and scored routes.
     pub fn get_stats(env: Env) -> RouterStats {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let names = Self::get_route_names(&env);
         let mut total_routes: u32 = 0;
         let mut active_routes: u32 = 0;
@@ -1537,6 +1577,7 @@ impl RouterCore {
     /// # Returns
     /// A `Vec<String>` containing up to `limit` route names.
     pub fn get_routes_paginated(env: Env, start: u32, limit: u32) -> Vec<String> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let names = Self::get_route_names(&env);
         let total = names.len();
         let mut page = Vec::new(&env);
@@ -1566,6 +1607,7 @@ impl RouterCore {
     /// # Returns
     /// `Some(canonical_name)` if `alias_name` is a registered alias, `None` otherwise.
     pub fn get_alias_target(env: Env, alias_name: String) -> Option<String> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage()
             .instance()
             .get::<DataKey, String>(&DataKey::Alias(alias_name))
@@ -1592,6 +1634,7 @@ impl RouterCore {
         name: String,
         score: RouteScore,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -1630,6 +1673,7 @@ impl RouterCore {
         caller: Address,
         scores: Vec<RouteScoreInput>,
     ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         caller.require_auth();
         router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
 
@@ -1672,6 +1716,7 @@ impl RouterCore {
     ///
     /// Returns `None` if no score has been set for the route.
     pub fn get_route_score(env: Env, name: String) -> Option<RouteScore> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         env.storage().instance().get(&DataKey::Score(name))
     }
 
@@ -1702,6 +1747,7 @@ impl RouterCore {
         min_score: i64,
         fallback_name: Option<String>,
     ) -> Result<Option<String>, RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let paused: bool = env
             .storage()
             .instance()
@@ -1773,6 +1819,7 @@ impl RouterCore {
     /// # Returns
     /// A `Vec<BatchResolveResult>` with one entry per input name, preserving order.
     pub fn batch_resolve(env: Env, names: Vec<String>) -> Vec<BatchResolveResult> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
         let mut results = Vec::new(&env);
         for name in names.iter() {
             let outcome = match Self::resolve(env.clone(), name) {


### PR DESCRIPTION
## Summary

- Adds `INSTANCE_TTL_THRESHOLD = 17280 * 30` (~30 days) and `INSTANCE_TTL_EXTEND_TO = 17280 * 60` (~60 days) constants
- Calls `router_common::extend_instance_ttl` at the start of all 37 public entry points in `router-core`, matching the pattern already used in `router-execution`
- Prevents the contract's instance storage from silently expiring between interactions

Closes #796