### PR TITLE
Fix super-admin blacklist bypass, expire_role bookkeeping gap, timelock dependency enforcement, and op_id collision reset

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -122,65 +122,7 @@ impl RouterAccess {
             return Err(AccessError::RoleNotFound);
         }
 
-        // Decrement active-member counter only if this grant was currently active.
-        // (If the role is expired, it may still exist in HasRole but shouldn't be
-        // counted as an active member.)
-        let was_active = Self::has_role_internal(&env, &target, &role);
-
-        env.storage().instance().remove(&key);
-
-        if was_active {
-            let current: u32 = env
-                .storage()
-                .instance()
-                .get::<DataKey, u32>(&DataKey::RoleMemberCount(role.clone()))
-                .unwrap_or(0u32);
-            let new_count = current.saturating_sub(1);
-            env.storage()
-                .instance()
-                .set(&DataKey::RoleMemberCount(role.clone()), &new_count);
-        }
-
-        let mut members: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::RoleMembers(role.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
-        if let Some(i) = members.iter().position(|a| a == target) {
-            members.remove(i as u32);
-        }
-        env.storage()
-            .instance()
-            .set(&DataKey::RoleMembers(role.clone()), &members);
-
-        let mut roles: Vec<String> = env
-            .storage()
-            .instance()
-            .get(&DataKey::AddressRoles(target.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
-        if let Some(i) = roles.iter().position(|r| r == role) {
-            roles.remove(i as u32);
-        }
-        env.storage()
-            .instance()
-            .set(&DataKey::AddressRoles(target.clone()), &roles);
-
-        env.storage()
-            .instance()
-            .remove(&DataKey::RoleExpiry(role.clone(), target.clone()));
-
-        // Keep RoleMemberCount consistent for expiry-based removal.
-        if Self::has_role_internal(&env, &target, &role) {
-            let current: u32 = env
-                .storage()
-                .instance()
-                .get::<DataKey, u32>(&DataKey::RoleMemberCount(role.clone()))
-                .unwrap_or(0u32);
-            let new_count = current.saturating_sub(1);
-            env.storage()
-                .instance()
-                .set(&DataKey::RoleMemberCount(role.clone()), &new_count);
-        }
+        Self::deactivate_role_grant(&env, &role, &target);
 
         env.events().publish(
             (Symbol::new(&env, router_common::EVENT_ROLE_REVOKED),),
@@ -590,6 +532,9 @@ impl RouterAccess {
     ) -> Result<(), AccessError> {
         current.require_auth();
         Self::require_super_admin(&env, &current)?;
+        if Self::is_blacklisted_internal(&env, &new_admin) {
+            return Err(AccessError::Blacklisted);
+        }
         env.storage()
             .instance()
             .set(&DataKey::SuperAdmin, &new_admin);
@@ -615,12 +560,7 @@ impl RouterAccess {
     ) -> Result<(), AccessError> {
         caller.require_auth();
         Self::require_super_admin(&env, &caller)?;
-        env.storage()
-            .instance()
-            .remove(&DataKey::RoleExpiry(role.clone(), target.clone()));
-        env.storage()
-            .instance()
-            .remove(&DataKey::HasRole(role.clone(), target.clone()));
+        Self::deactivate_role_grant(&env, &role, &target);
         env.events().publish(
             (Symbol::new(&env, router_common::EVENT_ROLE_EXPIRED),),
             (role, target),
@@ -629,6 +569,59 @@ impl RouterAccess {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Fully deactivates a role grant: removes `HasRole`, decrements
+    /// `RoleMemberCount` if the grant was currently active, and removes the
+    /// grant from `RoleMembers(role)`, `AddressRoles(target)`, and
+    /// `RoleExpiry(role, target)`. Shared by `revoke_role` and `expire_role`
+    /// so both leave identical, consistent bookkeeping behind.
+    fn deactivate_role_grant(env: &Env, role: &String, target: &Address) {
+        let was_active = Self::has_role_internal(env, target, role);
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::HasRole(role.clone(), target.clone()));
+
+        if was_active {
+            let current: u32 = env
+                .storage()
+                .instance()
+                .get::<DataKey, u32>(&DataKey::RoleMemberCount(role.clone()))
+                .unwrap_or(0u32);
+            let new_count = current.saturating_sub(1);
+            env.storage()
+                .instance()
+                .set(&DataKey::RoleMemberCount(role.clone()), &new_count);
+        }
+
+        let mut members: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::RoleMembers(role.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        if let Some(i) = members.iter().position(|a| a == *target) {
+            members.remove(i as u32);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::RoleMembers(role.clone()), &members);
+
+        let mut roles: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AddressRoles(target.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+        if let Some(i) = roles.iter().position(|r| r == *role) {
+            roles.remove(i as u32);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::AddressRoles(target.clone()), &roles);
+
+        env.storage()
+            .instance()
+            .remove(&DataKey::RoleExpiry(role.clone(), target.clone()));
+    }
 
     /// Track a role name in the AllRoles list if it hasn't been seen before.
     fn track_role_in_all_roles(env: &Env, role: &String) {
@@ -784,6 +777,9 @@ impl RouterAccess {
     }
 
     fn require_super_admin(env: &Env, caller: &Address) -> Result<(), AccessError> {
+        if Self::is_blacklisted_internal(env, caller) {
+            return Err(AccessError::Blacklisted);
+        }
         let admin: Address = env
             .storage()
             .instance()
@@ -1591,6 +1587,73 @@ mod tests {
         assert!(client.has_role(&user, &editor));
         assert!(client.has_role(&user, &viewer));
         assert_eq!(client.get_role_parent(&viewer), Some(editor));
+    }
+
+    // ── Issue #819: require_super_admin / transfer_super_admin blacklist gap ──
+
+    #[test]
+    fn test_blacklisted_address_cannot_regain_super_admin_via_transfer() {
+        let (env, admin_a, client) = setup();
+        let admin_b = Address::generate(&env);
+
+        // (1) A transfers super-admin to B.
+        client.transfer_super_admin(&admin_a, &admin_b);
+        assert_eq!(client.super_admin(), admin_b);
+
+        // (2) B blacklists A — allowed, since A is no longer the current
+        // super-admin.
+        client.blacklist(&admin_b, &admin_a);
+        assert!(client.is_blacklisted(&admin_a));
+
+        // (3) B attempts to transfer super-admin back to the now-blacklisted
+        // A. This must be rejected.
+        let result = client.try_transfer_super_admin(&admin_b, &admin_a);
+        assert_eq!(result, Err(Ok(AccessError::Blacklisted)));
+
+        // Super-admin remains B; A never regains privileged authority.
+        assert_eq!(client.super_admin(), admin_b);
+
+        // Even if A were to somehow be reinstated, a blacklisted caller must
+        // be rejected up front by require_super_admin. Simulate this by
+        // checking a blacklisted address can never pass the super-admin gate
+        // for any privileged action, using set_role_admin as a probe.
+        let role = String::from_str(&env, "operator");
+        let victim = Address::generate(&env);
+        let probe = client.try_set_role_admin(&admin_a, &role, &victim);
+        assert_eq!(probe, Err(Ok(AccessError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_transfer_super_admin_rejects_blacklisted_new_admin_directly() {
+        let (env, admin, client) = setup();
+        let blacklisted = Address::generate(&env);
+
+        client.blacklist(&admin, &blacklisted);
+        assert!(client.is_blacklisted(&blacklisted));
+
+        let result = client.try_transfer_super_admin(&admin, &blacklisted);
+        assert_eq!(result, Err(Ok(AccessError::Blacklisted)));
+        assert_eq!(client.super_admin(), admin);
+    }
+
+    // ── Issue #820: expire_role bookkeeping parity with revoke_role ──────────
+
+    #[test]
+    fn test_expire_role_clears_member_count_and_address_roles() {
+        let (env, admin, client) = setup();
+        let role = String::from_str(&env, "operator");
+        let user = Address::generate(&env);
+
+        client.grant_role(&admin, &user, &role, &Some(9999));
+        assert_eq!(client.get_role_member_count(&role), 1);
+        assert!(client.get_roles_for_address(&user).contains(&role));
+        assert!(client.get_role_members(&role).contains(&user));
+
+        client.expire_role(&admin, &role, &user);
+
+        assert_eq!(client.get_role_member_count(&role), 0);
+        assert!(!client.get_roles_for_address(&user).contains(&role));
+        assert!(!client.get_role_members(&role).contains(&user));
     }
 
     #[test]

--- a/contracts/router-timelock/src/lib.rs
+++ b/contracts/router-timelock/src/lib.rs
@@ -83,6 +83,10 @@ pub enum TimelockError {
     CircularDependency = 11,
     /// Dependency chain exceeds maximum allowed depth.
     DependencyTooDeep = 12,
+    /// An operation with this exact (description, target, eta) already exists.
+    AlreadyQueued = 13,
+    /// A dependency of this operation has not yet been executed.
+    DependencyNotExecuted = 14,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -165,6 +169,14 @@ impl RouterTimelock {
         preimage.append(&Bytes::from_array(&env, &eta_bytes));
 
         let op_id: Bytes = env.crypto().sha256(&preimage).into();
+
+        // Reject if an operation with this exact id (description + target + eta)
+        // already exists, regardless of its current state — otherwise a
+        // re-submission with matching parameters would silently overwrite an
+        // already-executed/cancelled op back to pending.
+        if env.storage().instance().has(&DataKey::Op(op_id.clone())) {
+            return Err(TimelockError::AlreadyQueued);
+        }
 
         // Validate no circular dependencies
         for dep_id in deps.iter() {
@@ -261,6 +273,8 @@ impl RouterTimelock {
         if now > op.eta + op.grace_period_seconds {
             return Err(TimelockError::Expired);
         }
+
+        Self::require_dependencies_executed(&env, &op_id)?;
 
         op.executed = true;
         env.storage()
@@ -666,6 +680,30 @@ impl RouterTimelock {
         Ok(())
     }
 
+    /// Require that every dependency recorded for `op_id` (via `DataKey::Deps`)
+    /// has itself been executed. A dependency that doesn't exist as an `Op`
+    /// (or exists but hasn't executed yet) blocks execution.
+    fn require_dependencies_executed(env: &Env, op_id: &Bytes) -> Result<(), TimelockError> {
+        let deps: Vec<Bytes> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Deps(op_id.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+
+        for dep_id in deps.iter() {
+            let dep_executed = env
+                .storage()
+                .instance()
+                .get::<DataKey, Op>(&DataKey::Op(dep_id))
+                .map(|dep_op| dep_op.executed)
+                .unwrap_or(false);
+            if !dep_executed {
+                return Err(TimelockError::DependencyNotExecuted);
+            }
+        }
+        Ok(())
+    }
+
     /// Remove an operation ID from the pending ops index.
     fn remove_from_pending_ops(env: &Env, op_id: &Bytes) {
         let pending: Vec<Bytes> = env
@@ -775,6 +813,39 @@ mod tests {
         assert_eq!(op.grace_period_seconds, custom_grace);
     }
 
+    // ── Issue #822: queue() op_id collision guard ────────────────────────────
+
+    #[test]
+    fn test_queue_rejects_op_id_collision_after_execution() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, RouterTimelock);
+        let client = RouterTimelockClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &0, &1000); // min_delay = 0 for full control over eta
+
+        let target = Address::generate(&env);
+        let desc = String::from_str(&env, "upgrade oracle");
+        let deps: Vec<Bytes> = Vec::new(&env);
+
+        let op_id = client.queue(&admin, &desc, &target, &0, &GRACE, &deps);
+        // delay is 0, so now == eta already; execute immediately.
+        client.execute(&admin, &op_id);
+        let op = client.get_op(&op_id).unwrap();
+        assert!(op.executed);
+
+        // Re-queue with identical description/target and a delay of 0 again.
+        // Since the ledger timestamp hasn't advanced, this reproduces the
+        // exact same (description, target, eta) triple and thus the same
+        // op_id — this must be rejected, not silently reset the already
+        // executed op back to pending.
+        let result = client.try_queue(&admin, &desc, &target, &0, &GRACE, &deps);
+        assert_eq!(result, Err(Ok(TimelockError::AlreadyQueued)));
+
+        let op_after = client.get_op(&op_id).unwrap();
+        assert!(op_after.executed);
+    }
+
     // ── execute ───────────────────────────────────────────────────────────────
 
     #[test]
@@ -802,6 +873,37 @@ mod tests {
 
         let op = client.get_op(&op_id).unwrap();
         assert!(op.executed);
+    }
+
+    // ── Issue #821: execute() enforces dependency completion ─────────────────
+
+    #[test]
+    fn test_execute_child_before_parent_executed_fails() {
+        let (env, admin, client) = setup();
+        let parent_target = Address::generate(&env);
+        let child_target = Address::generate(&env);
+        let parent_desc = String::from_str(&env, "register adapter");
+        let child_desc = String::from_str(&env, "upgrade adapter");
+        let no_deps: Vec<Bytes> = Vec::new(&env);
+
+        let parent_id = client.queue(&admin, &parent_desc, &parent_target, &3600, &GRACE, &no_deps);
+
+        let mut deps = Vec::new(&env);
+        deps.push_back(parent_id.clone());
+        let child_id = client.queue(&admin, &child_desc, &child_target, &3600, &GRACE, &deps);
+
+        env.ledger().with_mut(|l| l.timestamp += 3601);
+
+        // Child cannot execute before its dependency (parent) has executed.
+        let result = client.try_execute(&admin, &child_id);
+        assert_eq!(result, Err(Ok(TimelockError::DependencyNotExecuted)));
+
+        // Once the parent executes, the child can execute too.
+        client.execute(&admin, &parent_id);
+        client.execute(&admin, &child_id);
+
+        let child_op = client.get_op(&child_id).unwrap();
+        assert!(child_op.executed);
     }
 
     #[test]


### PR DESCRIPTION
Closes #819
Closes #820
Closes #821
Closes #822

- #819: `require_super_admin` now checks blacklist status, and `transfer_super_admin` rejects a blacklisted `new_admin`, closing the transfer -> blacklist -> transfer-back loophole that let a blacklisted address regain super-admin authority.
- #820: `expire_role` now shares the same bookkeeping helper as `revoke_role` (`deactivate_role_grant`), so `RoleMemberCount`, `RoleMembers`, and `AddressRoles` no longer go stale after a forced expiry.
- #821: `execute()` in router-timelock now requires every dependency recorded via `queue()`'s `deps` to have itself executed before allowing execution, enforcing the dependency ordering guarantee.
- #822: `queue()` now rejects re-submission of an identical `(description, target, eta)` triple if an `Op` with that id already exists, preventing an executed/cancelled operation from being silently reset to pending.

Regression tests added for all 4 issues.