### PR TITLE
docs(docs): remove stale scratch checklist from top of TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,3 @@
-- [x] Explore router-multicall contract code and existing tests (read contracts/router-multicall/src/lib.rs)
-- [x] Add/adjust tests to verify stored batch results behavior via get_batch_result/get_batch_results
-- [x] Fix compilation issues in tests due to Soroban client return types (Option/Vec handling)
-- [x] Run `cargo test -p router-multicall` and ensure tests pass
 # TODO
 
 ## Role membership transfer between addresses (router-access)


### PR DESCRIPTION
## Summary
Removes four completed checklist items that sat **above** the `# TODO` heading in `TODO.md`. These were leftover scratch notes from a prior `router-multicall` PR (exploring the contract, adjusting tests, fixing compilation, running `cargo test`), not current project work. Their placement before the heading disrupted the document structure and created confusion about the actual outstanding tasks.

The `# TODO` heading is now the file's first line, followed immediately by the active "Role membership transfer between addresses (router-access)" task list.

## Changes
- Deleted lines 1–4 (the stale `[x]` checklist) from `TODO.md`.

## Testing
Documentation-only change — no code affected, so no tests are required. Verified the diff removes only the four stale lines and that `# TODO` now leads the file.

## Follow-up
None.

Closes #923