### PR TITLE
docs(docs): fix dead link to INTEGRATION_TESTS.md referenced in three files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ cargo test -p router-metrics-exporter
 cargo test --test integration_tests -- --ignored --test-threads=1 --nocapture
 ```
 
-See [INTEGRATION_TESTS.md](INTEGRATION_TESTS.md) for full details.
+See [integration-tests/tests/README.md](integration-tests/tests/README.md) for full details.
 
 ### Build WASM artifacts
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Run integration tests on Stellar testnet:
 cargo test --test integration_tests -- --ignored --test-threads=1 --nocapture
 ```
 
-See [INTEGRATION_TESTS.md](INTEGRATION_TESTS.md) for detailed integration test documentation.
+See [integration-tests/tests/README.md](integration-tests/tests/README.md) for detailed integration test documentation.
 
 ### Build for Deployment (WASM)
 

--- a/integration-tests/tests/README.md
+++ b/integration-tests/tests/README.md
@@ -120,4 +120,4 @@ let core = fixture.router_core.as_ref().unwrap();
 
 ## Documentation
 
-See [INTEGRATION_TESTS.md](../INTEGRATION_TESTS.md) for comprehensive documentation.
+See the [Contributing guide](../../CONTRIBUTING.md) for comprehensive documentation.


### PR DESCRIPTION
Closes #919.

`INTEGRATION_TESTS.md` does not exist anywhere in the repo, so the three links to it were dead (404):
- `README.md` (line 223)
- `CONTRIBUTING.md` (line 108)
- `integration-tests/tests/README.md` (last line)

Fix: repoint each link to documentation that actually exists. The two root files now link to `integration-tests/tests/README.md` (the real integration-test docs), and that file's self-referential dead link now points to the Contributing guide. No content or code changes.