### PR TITLE
fix: enforce role caps and configurable scoring weights

### DIFF
--- a/contracts/router-access/src/lib.rs
+++ b/contracts/router-access/src/lib.rs
@@ -10,6 +10,14 @@ use soroban_sdk::{
 
 const MAX_HIERARCHY_DEPTH: u32 = 16;
 
+/// Default cap on the total number of distinct role names the system may hold.
+/// Prevents unbounded `AllRoles` growth. Configurable via `set_role_limits`.
+const DEFAULT_MAX_ROLES: u32 = 100;
+
+/// Default cap on the number of addresses that may hold a single role.
+/// Prevents unbounded `RoleMembers` growth. Configurable via `set_role_limits`.
+const DEFAULT_MAX_GRANTS_PER_ROLE: u32 = 1_000;
+
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -26,6 +34,9 @@ pub enum DataKey {
     RoleExpiry(String, Address),
     RoleParent(String), // child role -> parent role
     AllRoles,           // Vec<String> — all roles ever defined in the system
+
+    /// Configurable limits: (max_roles, max_grants_per_role)
+    RoleLimits,
 }
 
 // ── Errors ────────────────────────────────────────────────────────────────────
@@ -44,6 +55,10 @@ pub enum AccessError {
     HierarchyCycle = 9,
     InvalidExpiry = 10,
     HierarchyTooDeep = 11,
+    /// The system has reached its `MaxRoles` cap; no new role names may be introduced.
+    MaxRolesExceeded = 12,
+    /// The role has reached its `MaxGrantsPerRole` cap; no further addresses may be granted this role.
+    MaxGrantsPerRoleExceeded = 13,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -62,6 +77,45 @@ impl RouterAccess {
             .instance()
             .set(&DataKey::SuperAdmin, &super_admin);
         Ok(())
+    }
+
+    /// Configure the role-system limits.
+    ///
+    /// Both limits are enforced at grant/introduction time:
+    /// - `max_roles` — maximum number of *distinct* role names ever introduced
+    ///   into the system (tracked in `AllRoles`).  Pass `0` to restore the
+    ///   default (`DEFAULT_MAX_ROLES`).
+    /// - `max_grants_per_role` — maximum number of addresses that may
+    ///   simultaneously hold a given role (tracked by `RoleMemberCount`).
+    ///   Pass `0` to restore the default (`DEFAULT_MAX_GRANTS_PER_ROLE`).
+    ///
+    /// Only the super-admin may call this function.
+    pub fn set_role_limits(
+        env: Env,
+        caller: Address,
+        max_roles: u32,
+        max_grants_per_role: u32,
+    ) -> Result<(), AccessError> {
+        caller.require_auth();
+        router_common::require_admin_simple!(&env, &caller, &DataKey::SuperAdmin, AccessError)?;
+        let effective_max_roles = if max_roles == 0 { DEFAULT_MAX_ROLES } else { max_roles };
+        let effective_max_grants = if max_grants_per_role == 0 {
+            DEFAULT_MAX_GRANTS_PER_ROLE
+        } else {
+            max_grants_per_role
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::RoleLimits, &(effective_max_roles, effective_max_grants));
+        Ok(())
+    }
+
+    /// Return the currently active role limits as `(max_roles, max_grants_per_role)`.
+    ///
+    /// Falls back to the compile-time defaults when no explicit limits have been
+    /// configured via [`set_role_limits`].
+    pub fn get_role_limits(env: Env) -> (u32, u32) {
+        Self::role_limits_internal(&env)
     }
 
     /// Grant a role to an address.
@@ -188,7 +242,7 @@ impl RouterAccess {
             return Err(AccessError::Blacklisted);
         }
         // Track this role in AllRoles if it's the first time we've seen it
-        Self::track_role_in_all_roles(&env, &role);
+        Self::track_role_in_all_roles(&env, &role)?;
         env.storage()
             .instance()
             .set(&DataKey::RoleAdmin(role.clone()), &admin);
@@ -217,8 +271,8 @@ impl RouterAccess {
         router_common::require_admin_simple!(&env, &caller, &DataKey::SuperAdmin, AccessError)?;
         Self::ensure_no_role_parent_cycle(&env, &role, &parent_role)?;
 
-        Self::track_role_in_all_roles(&env, &role);
-        Self::track_role_in_all_roles(&env, &parent_role);
+        Self::track_role_in_all_roles(&env, &role)?;
+        Self::track_role_in_all_roles(&env, &parent_role)?;
 
         env.storage()
             .instance()
@@ -468,7 +522,7 @@ impl RouterAccess {
         }
 
         // Track this role in AllRoles if it's the first time we've seen it.
-        Self::track_role_in_all_roles(&env, &role);
+        Self::track_role_in_all_roles(&env, &role)?;
 
         env.storage()
             .instance()
@@ -632,16 +686,24 @@ impl RouterAccess {
     }
 
     /// Track a role name in the AllRoles list if it hasn't been seen before.
-    fn track_role_in_all_roles(env: &Env, role: &String) {
+    ///
+    /// Returns `Err(AccessError::MaxRolesExceeded)` when the system has already
+    /// reached its configured `max_roles` cap and `role` is a brand-new name.
+    fn track_role_in_all_roles(env: &Env, role: &String) -> Result<(), AccessError> {
         let mut all_roles: Vec<String> = env
             .storage()
             .instance()
             .get(&DataKey::AllRoles)
             .unwrap_or_else(|| Vec::new(env));
         if !all_roles.iter().any(|r| r == *role) {
+            let (max_roles, _) = Self::role_limits_internal(env);
+            if all_roles.len() >= max_roles {
+                return Err(AccessError::MaxRolesExceeded);
+            }
             all_roles.push_back(role.clone());
             env.storage().instance().set(&DataKey::AllRoles, &all_roles);
         }
+        Ok(())
     }
 
     fn access_error_to_batch(env: &Env, err: AccessError) -> router_common::BatchItemError {
@@ -673,7 +735,21 @@ impl RouterAccess {
             AccessError::HierarchyTooDeep => router_common::BatchItemError::Custom(
                 soroban_sdk::String::from_str(env, "HierarchyTooDeep"),
             ),
+            AccessError::MaxRolesExceeded => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "MaxRolesExceeded"),
+            ),
+            AccessError::MaxGrantsPerRoleExceeded => router_common::BatchItemError::Custom(
+                soroban_sdk::String::from_str(env, "MaxGrantsPerRoleExceeded"),
+            ),
         }
+    }
+
+    /// Read `(max_roles, max_grants_per_role)` from storage, falling back to defaults.
+    fn role_limits_internal(env: &Env) -> (u32, u32) {
+        env.storage()
+            .instance()
+            .get::<DataKey, (u32, u32)>(&DataKey::RoleLimits)
+            .unwrap_or((DEFAULT_MAX_ROLES, DEFAULT_MAX_GRANTS_PER_ROLE))
     }
 
     /// Validates a prospective `role -> parent_role` edge: rejects it if it
@@ -755,7 +831,7 @@ impl RouterAccess {
         }
 
         // Track this role in AllRoles if it's the first time we've seen it
-        Self::track_role_in_all_roles(env, role);
+        Self::track_role_in_all_roles(env, role)?;
 
         let expiry_timestamp = match expires_in {
             Some(seconds) => env
@@ -776,6 +852,16 @@ impl RouterAccess {
             .get(&DataKey::RoleMembers(role.clone()))
             .unwrap_or_else(|| Vec::new(env));
         if !members.iter().any(|a| a == *account) {
+            // Enforce MaxGrantsPerRole before adding a new member.
+            let (_, max_grants) = Self::role_limits_internal(env);
+            let current_count: u32 = env
+                .storage()
+                .instance()
+                .get::<DataKey, u32>(&DataKey::RoleMemberCount(role.clone()))
+                .unwrap_or(0u32);
+            if current_count >= max_grants {
+                return Err(AccessError::MaxGrantsPerRoleExceeded);
+            }
             members.push_back(account.clone());
         }
         env.storage()

--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -57,6 +57,9 @@ pub enum DataKey {
     Metadata(String),     // name -> RouteMetadata (stored separately; avoids nested contracttype)
     Dependencies(String), // name -> Vec<String> of direct dependencies
     BestRoute,            // cached name of the highest-scoring non-paused route, if any
+
+    /// Configurable weights used by the composite scoring formula.
+    ScoringWeights,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -105,7 +108,7 @@ pub struct RouteScoreInput {
 /// Scoring attributes for a route used in path selection.
 ///
 /// Higher scores indicate more preferred routes. The composite score is
-/// computed as: `liquidity_score + reliability_score - fee_bps / 10`.
+/// computed as: `liquidity_weight * liquidity_score + reliability_weight * reliability_score - fee_bps / fee_divisor`.
 /// All fields are set by the admin and reflect off-chain measurements.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -116,6 +119,25 @@ pub struct RouteScore {
     pub fee_bps: u32,
     /// Historical reliability score (0–100). Higher = more reliable.
     pub reliability_score: u32,
+}
+
+/// Configurable weights for the composite route-scoring formula.
+///
+/// The composite score is:
+/// `liquidity_weight * liquidity_score + reliability_weight * reliability_score - fee_bps / fee_divisor`
+///
+/// Stored under [`DataKey::ScoringWeights`] and set by an admin via
+/// [`RouterCore::set_scoring_weights`].  When no weights have been configured
+/// the system falls back to `DEFAULT_SCORING_WEIGHTS`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ScoringWeights {
+    /// Multiplier applied to `liquidity_score`. Default: 1.
+    pub liquidity_weight: i64,
+    /// Multiplier applied to `reliability_score`. Default: 1.
+    pub reliability_weight: i64,
+    /// Divisor applied to `fee_bps` (must be > 0). Default: 10.
+    pub fee_divisor: i64,
 }
 
 /// Resolution-specific errors returned by [`RouterCore::batch_resolve`].
@@ -183,6 +205,8 @@ pub enum RouterError {
     InvalidScore = 14,
     InvalidTtlExtension = 15,
     RecursionLimitExceeded = 15,
+    /// `fee_divisor` must be positive (> 0) when configuring scoring weights.
+    InvalidScoringWeights = 16,
 }
 
 /// Maximum allowed recursion depth for dependency resolution.
@@ -1624,6 +1648,57 @@ impl RouterCore {
             .get::<DataKey, String>(&DataKey::Alias(alias_name))
     }
 
+    /// Configure the weights used in the composite route-scoring formula.
+    ///
+    /// The composite score is computed as:
+    /// `liquidity_weight * liquidity_score + reliability_weight * reliability_score - fee_bps / fee_divisor`
+    ///
+    /// Stored persistently so the formula adapts to different deployment
+    /// scenarios (e.g. fee-sensitive vs. reliability-sensitive) without
+    /// redeploying the contract.
+    ///
+    /// # Arguments
+    /// * `env`                - The Soroban environment.
+    /// * `caller`             - Must be the admin.
+    /// * `weights`            - The [`ScoringWeights`] to persist.
+    ///
+    /// # Errors
+    /// * [`RouterError::Unauthorized`]          — if `caller` is not the admin.
+    /// * [`RouterError::NotInitialized`]        — if the contract is not initialized.
+    /// * [`RouterError::InvalidScoringWeights`] — if `fee_divisor` is ≤ 0 or any
+    ///   weight is negative.
+    pub fn set_scoring_weights(
+        env: Env,
+        caller: Address,
+        weights: ScoringWeights,
+    ) -> Result<(), RouterError> {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+        caller.require_auth();
+        router_common::require_admin_simple!(&env, &caller, &DataKey::Admin, RouterError)?;
+
+        if weights.fee_divisor <= 0 || weights.liquidity_weight < 0 || weights.reliability_weight < 0 {
+            return Err(RouterError::InvalidScoringWeights);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ScoringWeights, &weights);
+
+        // Re-rank routes using the new weights.
+        Self::recompute_best_route(&env);
+
+        Ok(())
+    }
+
+    /// Return the currently configured [`ScoringWeights`].
+    ///
+    /// Falls back to `(liquidity_weight=1, reliability_weight=1, fee_divisor=10)`
+    /// when no weights have been explicitly set via [`set_scoring_weights`].
+    pub fn get_scoring_weights(env: Env) -> ScoringWeights {
+        router_common::extend_instance_ttl(&env, INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+        Self::scoring_weights_internal(&env)
+    }
+
     /// Set or update the scoring attributes for a route.
     ///
     /// Scores are used by [`get_best_route`] to select the optimal path from a
@@ -2021,6 +2096,9 @@ impl RouterCore {
         let mut best_name: Option<String> = None;
         let mut best_score: i64 = i64::MIN;
 
+        // Load configurable weights (falls back to defaults when not set).
+        let weights = Self::scoring_weights_internal(env);
+
         for name in names.iter() {
             // Skip missing or paused routes
             match env
@@ -2039,11 +2117,13 @@ impl RouterCore {
                     None => continue,
                 };
 
-            // Composite score: liquidity + reliability - fee_bps/10
-            let composite = (score.liquidity_score as i64)
-                .checked_add(score.reliability_score as i64)
-                .unwrap()
-                - (score.fee_bps as i64 / 10);
+            // Composite score using configurable weights:
+            //   liquidity_weight * liquidity_score
+            // + reliability_weight * reliability_score
+            // - fee_bps / fee_divisor
+            let composite = weights.liquidity_weight * (score.liquidity_score as i64)
+                + weights.reliability_weight * (score.reliability_score as i64)
+                - (score.fee_bps as i64 / weights.fee_divisor);
 
             if composite > best_score {
                 best_score = composite;
@@ -2061,6 +2141,20 @@ impl RouterCore {
             }
             None => env.storage().instance().remove(&DataKey::BestRoute),
         }
+    }
+
+    /// Return the active [`ScoringWeights`], falling back to safe defaults
+    /// `(liquidity_weight=1, reliability_weight=1, fee_divisor=10)` when no
+    /// explicit weights have been stored via [`set_scoring_weights`].
+    fn scoring_weights_internal(env: &Env) -> ScoringWeights {
+        env.storage()
+            .instance()
+            .get::<DataKey, ScoringWeights>(&DataKey::ScoringWeights)
+            .unwrap_or(ScoringWeights {
+                liquidity_weight: 1,
+                reliability_weight: 1,
+                fee_divisor: 10,
+            })
     }
 
     /// Validates a route name for use in register_route and add_alias.

--- a/contracts/router-core/src/scoring.rs
+++ b/contracts/router-core/src/scoring.rs
@@ -6,7 +6,7 @@
 
 use soroban_sdk::{Env, String, Symbol};
 
-use crate::{is_route_expired, DataKey, RouteEntry, RouteScore};
+use crate::{is_route_expired, DataKey, RouteEntry, RouteScore, ScoringWeights};
 
 /// Recompute and cache the highest-scoring, non-paused route.
 ///
@@ -14,6 +14,12 @@ use crate::{is_route_expired, DataKey, RouteEntry, RouteScore};
 /// [`DataKey::BestRoute`] (or removes the key when no scored, non-paused
 /// route exists). Called from every write path that can change the outcome:
 /// scoring, pausing, and route removal.
+///
+/// The composite formula uses configurable weights stored under
+/// [`DataKey::ScoringWeights`]:
+/// `liquidity_weight * liquidity_score + reliability_weight * reliability_score - fee_bps / fee_divisor`
+///
+/// Falls back to `(1, 1, 10)` when no weights have been explicitly set.
 pub fn recompute_best_route(env: &Env) {
     let names: soroban_sdk::Vec<String> = env
         .storage()
@@ -23,6 +29,17 @@ pub fn recompute_best_route(env: &Env) {
 
     let mut best_name: Option<String> = None;
     let mut best_score: i64 = i64::MIN;
+
+    // Load configurable weights (falls back to defaults when not set).
+    let weights: ScoringWeights = env
+        .storage()
+        .instance()
+        .get::<DataKey, ScoringWeights>(&DataKey::ScoringWeights)
+        .unwrap_or(ScoringWeights {
+            liquidity_weight: 1,
+            reliability_weight: 1,
+            fee_divisor: 10,
+        });
 
     for name in names.iter() {
         // Skip missing, paused, or expired routes
@@ -41,9 +58,13 @@ pub fn recompute_best_route(env: &Env) {
             None => continue,
         };
 
-        // Composite score: liquidity + reliability - fee_bps/10
-        let composite: i64 = score.liquidity_score as i64 + score.reliability_score as i64
-            - (score.fee_bps as i64 / 10);
+        // Composite score using configurable weights:
+        //   liquidity_weight * liquidity_score
+        // + reliability_weight * reliability_score
+        // - fee_bps / fee_divisor
+        let composite: i64 = weights.liquidity_weight * (score.liquidity_score as i64)
+            + weights.reliability_weight * (score.reliability_score as i64)
+            - (score.fee_bps as i64 / weights.fee_divisor);
 
         if composite > best_score {
             best_score = composite;


### PR DESCRIPTION


closes #718
closes #717


## Summary

Two security/correctness fixes addressing unbounded storage growth and hardcoded scoring weights.

### A — Unbounded role storage (router-access)

**Problem:** An admin (or compromised key) could create unlimited distinct roles and grant them to unlimited addresses, causing unbounded `AllRoles` and `RoleMembers` storage growth.

**Fix:**
- `DEFAULT_MAX_ROLES = 100` and `DEFAULT_MAX_GRANTS_PER_ROLE = 1000` compile-time defaults
- New `DataKey::RoleLimits` persists configurable overrides across upgrades
- New error variants: `MaxRolesExceeded (12)` and `MaxGrantsPerRoleExceeded (13)`
- New admin functions: `set_role_limits` / `get_role_limits`
- `track_role_in_all_roles` now returns `Result` and enforces the roles cap before inserting
- `grant_role_internal` checks `RoleMemberCount >= max_grants` (O(1) counter) before adding a new member

### B — Hardcoded scoring weights (router-core)

**Problem:** Composite route score used hardcoded weights (1:1 liquidity/reliability, fee divisor 10), impossible to tune without redeploying.

**Fix:**
- New `ScoringWeights { liquidity_weight, reliability_weight, fee_divisor }` contracttype stored under `DataKey::ScoringWeights`
- New error variant: `InvalidScoringWeights (16)`
- New admin functions: `set_scoring_weights` / `get_scoring_weights`
- `recompute_best_route` updated in both `lib.rs` and `scoring.rs` to load stored weights
- Defaults reproduce the original formula exactly — no behaviour change on existing deployments
