### PR TITLE
Fix/issues 888 889 890 891

### DIFF
--- a/contracts/router-middleware/src/lib.rs
+++ b/contracts/router-middleware/src/lib.rs
@@ -169,13 +169,21 @@ pub struct CallLogSummary {
 #[contracterror]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum MiddlewareError {
+    /// `initialize` was called on a contract that already has an admin set.
     AlreadyInitialized = 1,
+    /// An admin-gated call was made before `initialize` set up the contract.
     NotInitialized = 2,
+    /// A non-admin caller attempted to invoke an admin-gated function.
     Unauthorized = 3,
+    /// The rate limit for the route has been exceeded for this caller.
     RateLimitExceeded = 4,
+    /// The route is disabled and cannot be called via middleware.
     RouteDisabled = 5,
+    /// Middleware is globally disabled and no calls can proceed.
     MiddlewareDisabled = 6,
+    /// Route configuration is invalid (e.g., window_seconds is 0 with max_calls > 0).
     InvalidConfig = 7,
+    /// The circuit breaker for this route is open (failure threshold exceeded).
     CircuitOpen = 8,
     /// A re-entrant call to `pre_call` was detected for this route.
     /// The `Executing` guard for this route can be cleared by an admin

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -756,6 +756,50 @@ mod tests {
     }
 
     #[test]
+    fn test_get_route_fee_tiers_returns_empty_when_not_set() {
+        let (env, _admin, client) = setup();
+        let route = String::from_str(&env, "uniswap");
+        let tiers = client.get_route_fee_tiers(&route);
+        assert!(tiers.is_empty());
+    }
+
+    #[test]
+    fn test_get_route_fee_tiers_returns_sorted_tiers() {
+        let (env, admin, client) = setup();
+        let route = String::from_str(&env, "uniswap");
+
+        // Create tiers in unsorted order
+        let tiers = vec![
+            &env,
+            FeeTier {
+                min_amount: 100000,
+                fee_bps: 10,
+            },
+            FeeTier {
+                min_amount: 0,
+                fee_bps: 50,
+            },
+            FeeTier {
+                min_amount: 10000,
+                fee_bps: 30,
+            },
+        ];
+
+        client.set_route_fee_tiers(&admin, &route, &tiers);
+
+        let retrieved_tiers = client.get_route_fee_tiers(&route);
+        assert_eq!(retrieved_tiers.len(), 3);
+
+        // Verify tiers are sorted by min_amount ascending
+        assert_eq!(retrieved_tiers.get(0).unwrap().min_amount, 0);
+        assert_eq!(retrieved_tiers.get(0).unwrap().fee_bps, 50);
+        assert_eq!(retrieved_tiers.get(1).unwrap().min_amount, 10000);
+        assert_eq!(retrieved_tiers.get(1).unwrap().fee_bps, 30);
+        assert_eq!(retrieved_tiers.get(2).unwrap().min_amount, 100000);
+        assert_eq!(retrieved_tiers.get(2).unwrap().fee_bps, 10);
+    }
+
+    #[test]
     fn test_get_quote_with_default_fee() {
         let (env, _admin, client) = setup();
         let token_in = Address::generate(&env);

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -1158,6 +1158,33 @@ mod tests {
     }
 
     #[test]
+    fn test_unauthorized_set_default_fee_fails() {
+        let (env, _admin, client) = setup();
+        let unauthorized = Address::generate(&env);
+        let result = client.try_set_default_fee(&unauthorized, &200);
+        assert_eq!(result, Err(Ok(QuoteError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_unauthorized_set_route_fee_tiers_fails() {
+        let (env, _admin, client) = setup();
+        let unauthorized = Address::generate(&env);
+        let route = String::from_str(&env, "uniswap");
+        let tiers = Vec::new(&env);
+        let result = client.try_set_route_fee_tiers(&unauthorized, &route, &tiers);
+        assert_eq!(result, Err(Ok(QuoteError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_unauthorized_transfer_admin_fails() {
+        let (env, _admin, client) = setup();
+        let unauthorized = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let result = client.try_transfer_admin(&unauthorized, &new_admin);
+        assert_eq!(result, Err(Ok(QuoteError::Unauthorized)));
+    }
+
+    #[test]
     fn test_admin_getter() {
         let (env, admin, client) = setup();
         assert_eq!(client.admin(), admin);

--- a/contracts/router-quote/src/lib.rs
+++ b/contracts/router-quote/src/lib.rs
@@ -322,14 +322,14 @@ impl RouterQuote {
     /// Router name and Fee in basis points.
     pub fn get_all_configured_routes(env: Env) -> Vec<(String, u32)> {
         let routes = Self::read_configured_routes(&env);
-        let mut configures_routes = Vec::new(&env);
+        let mut configured_routes = Vec::new(&env);
 
         for route in routes {
             if let Ok(fee) = Self::get_route_fee(env.clone(), route.clone()) {
-                configures_routes.push_back((route, fee));
+                configured_routes.push_back((route, fee));
             }
         }
-        configures_routes
+        configured_routes
     }
 
     /// Get a quote for a single route with configurable fee.


### PR DESCRIPTION
  ## Summary

  Fix misspelling, add comprehensive test coverage, and improve documentation for router-quote and router-middleware contracts.

  ## Changes

  - **#888**: Fix misspelled variable `configures_routes` → `configured_routes` in `get_all_configured_routes()`
  - **#889**: Add direct unit tests for `get_route_fee_tiers` getter (empty case and sorted tiers validation)
  - **#890**: Add unauthorized-caller tests for admin-gated functions (`set_default_fee`, `set_route_fee_tiers`, `transfer_admin`)
  - **#891**: Add per-variant documentation comments to `MiddlewareError` enum

  Closes #888
  Closes #889
  Closes #890
  Closes #891