### PR TITLE
docs(sdk): add code fences; test(api-server): malformed JSON /simulate body

### DIFF
--- a/api-server/src/tests.rs
+++ b/api-server/src/tests.rs
@@ -352,6 +352,26 @@ async fn test_simulate_empty_body_returns_400_or_422() {
 }
 
 #[tokio::test]
+async fn test_simulate_malformed_json_body_returns_400_or_422() {
+    let app = test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/simulate")
+                .header("content-type", "application/json")
+                .body(Body::from("not json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status() == StatusCode::BAD_REQUEST
+            || resp.status() == StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
+
+#[tokio::test]
 async fn test_get_route_returns_500_when_core_not_configured() {
     let app = test_app();
     let resp = app

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -3,9 +3,14 @@
 A client library for interacting with the stellar-router contracts from JS/TS.
 
 ## Installation
+
+```bash
 npm install stellar-router-sdk
+```
 
 ## Quick Start
+
+```typescript
 import { RouterClient } from "stellar-router-sdk";
 
 const client = new RouterClient({
@@ -16,6 +21,7 @@ const client = new RouterClient({
 
 const address = await client.resolve("oracle");
 await client.registerRoute("oracle", "C...", { description: "Price feed" });
+```
 
 ## API
 - resolve(name) → Promise<string>
@@ -31,4 +37,7 @@ await client.registerRoute("oracle", "C...", { description: "Price feed" });
 All methods throw RouterSdkError with a .code (e.g. "RouteNotFound") on failure.
 
 ## Publishing
+
+```bash
 npm version patch && npm publish
+```


### PR DESCRIPTION
## Summary
- Adds markdown code fences around the Installation, Quick Start, and Publishing snippets in `docs/sdk.md`, matching the style used in the rest of `docs/` (e.g. `docs/signing-abstraction.md`).
- Adds `test_simulate_malformed_json_body_returns_400_or_422` in `api-server/src/tests.rs`, which sends a non-JSON body (`"not json"`) to `POST /simulate` to exercise axum's `Json` extractor rejection path, complementing the existing `test_simulate_empty_body_returns_400_or_422` test which only covers syntactically-valid-but-empty JSON.

Closes #920
Closes #918

## Test plan
- [x] Manually reviewed rendered `docs/sdk.md` for correct fencing/formatting
- [ ] `cargo test -p api-server test_simulate_malformed_json_body_returns_400_or_422` (could not run locally — no Rust toolchain in this environment; please verify in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)