### PR TITLE
fix(router-common,metrics): resolve issues #900, #901, #902, #907

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,41 @@
 target/
 storage-profile.txt
+
+# Test snapshots and output
 **/test_snapshots/
 **/test_output.txt
-benches/src/scrap-menu/
-.DS_Store
+**/*.snap.new
+**/*.snap
+**/snapshots/
+
+# Build artifacts
 *.wasm
 artifacts/
+
+# Benchmarks scratch
+benches/src/scrap-menu/
+
+# Secrets and local config
 .env
 .env.*
+
+# Logs and temp files
 *.log
 *.tmp
 *.temp
 /tmp/
+
+# OS / editor files
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Profiling / coverage output
+*.profraw
+*.profdata
+lcov.info
+coverage/

--- a/contracts/router-common/EVENT_NAMING_CONVENTION.md
+++ b/contracts/router-common/EVENT_NAMING_CONVENTION.md
@@ -61,11 +61,14 @@ All smart contracts in the stellar-router suite follow a consistent event naming
 - `admin_transferred` — (old_admin, new_admin)
 
 ### router-middleware
+- `pre_call` — (caller, route)
+- `post_call` — (caller, route, success)
 - `rate_limit_exceeded` — (caller, route)
-- `call_logged` — (caller, route, timestamp, success)
+- `rate_limit_throttled` — (caller, route)
 - `middleware_enabled` — (enabled)
-- `route_config_updated` — (route_name, config)
-- `circuit_breaker_opened` — (route_name)
+- `circuit_opened` — (route_name)
+- `circuit_closed` — (route_name)
+- `call_log_cleared` — (route_name)
 - `admin_transferred` — (old_admin, new_admin)
 
 ### router-execution

--- a/contracts/router-common/src/lib.rs
+++ b/contracts/router-common/src/lib.rs
@@ -297,7 +297,10 @@ pub struct BatchFailure {
     pub error: BatchItemError,
 }
 
-/// Standardized per-index batch operation result for void operations (`T = BatchUnit`).
+/// Standardized per-index batch operation result for void operations.
+///
+/// Tracks indexed successes ([`BatchSuccess`]) and indexed failures ([`BatchFailure`])
+/// for batch operations whose items do not return a value.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct BatchResult {
@@ -305,7 +308,10 @@ pub struct BatchResult {
     pub failures: Vec<BatchFailure>,
 }
 
-/// Standardized per-index batch operation result for call operations (`T = CallResult`).
+/// Standardized per-index batch operation result for call operations.
+///
+/// Tracks indexed successes ([`BatchCallSuccess`]) and indexed failures
+/// ([`BatchFailure`]) for batch operations whose items return a [`CallResult`].
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct BatchCallResult {
@@ -426,6 +432,7 @@ pub fn is_whitespace_only(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::{contract, contracterror, testutils::Address as _, Env};
 
     #[test]
     fn test_empty_string_is_whitespace_only() {
@@ -465,6 +472,189 @@ mod tests {
     #[test]
     fn test_name_with_surrounding_spaces_is_not_whitespace_only() {
         assert!(!is_whitespace_only(" oracle "));
+    }
+
+    // ── require_admin! tests ──────────────────────────────────────────────────
+
+    /// Shared contract stub and error type used by the require_admin! tests below.
+    #[contract]
+    struct AdminTestContract;
+
+    #[contracterror]
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    enum AdminTestError {
+        NotInitialized = 1,
+        Unauthorized = 2,
+    }
+
+    /// require_admin! returns Ok(()) when the caller matches the stored admin.
+    #[test]
+    fn require_admin_passes_for_correct_admin() {
+        let env = Env::default();
+        let id = env.register_contract(None, AdminTestContract);
+        env.as_contract(&id, || {
+            let admin = Address::generate(&env);
+            env.storage()
+                .instance()
+                .set(&CommonDataKey::Admin, &admin);
+
+            let result = require_admin!(
+                &env,
+                &admin,
+                &CommonDataKey::Admin,
+                AdminTestError::NotInitialized,
+                AdminTestError::Unauthorized
+            );
+            assert_eq!(result, Ok(()));
+        });
+    }
+
+    /// require_admin! returns Err(Unauthorized) when the caller is not the admin.
+    #[test]
+    fn require_admin_rejects_non_admin_caller() {
+        let env = Env::default();
+        let id = env.register_contract(None, AdminTestContract);
+        env.as_contract(&id, || {
+            let admin = Address::generate(&env);
+            let attacker = Address::generate(&env);
+            env.storage()
+                .instance()
+                .set(&CommonDataKey::Admin, &admin);
+
+            let result = require_admin!(
+                &env,
+                &attacker,
+                &CommonDataKey::Admin,
+                AdminTestError::NotInitialized,
+                AdminTestError::Unauthorized
+            );
+            assert_eq!(result, Err(AdminTestError::Unauthorized));
+        });
+    }
+
+    /// require_admin! returns Err(NotInitialized) when no admin key is present in storage.
+    #[test]
+    fn require_admin_returns_not_initialized_when_key_absent() {
+        let env = Env::default();
+        let id = env.register_contract(None, AdminTestContract);
+        env.as_contract(&id, || {
+            let caller = Address::generate(&env);
+
+            let result = require_admin!(
+                &env,
+                &caller,
+                &CommonDataKey::Admin,
+                AdminTestError::NotInitialized,
+                AdminTestError::Unauthorized
+            );
+            assert_eq!(result, Err(AdminTestError::NotInitialized));
+        });
+    }
+
+    // ── require_admin_simple! tests ───────────────────────────────────────────
+
+    /// require_admin_simple! is a convenience wrapper over require_admin! that
+    /// automatically uses NotInitialized and Unauthorized from the error type.
+    /// It must pass for the correct admin.
+    #[test]
+    fn require_admin_simple_passes_for_correct_admin() {
+        let env = Env::default();
+        let id = env.register_contract(None, AdminTestContract);
+        env.as_contract(&id, || {
+            let admin = Address::generate(&env);
+            env.storage()
+                .instance()
+                .set(&CommonDataKey::Admin, &admin);
+
+            let result =
+                require_admin_simple!(&env, &admin, &CommonDataKey::Admin, AdminTestError);
+            assert_eq!(result, Ok(()));
+        });
+    }
+
+    /// require_admin_simple! must return Err(Unauthorized) for a non-admin caller.
+    #[test]
+    fn require_admin_simple_rejects_non_admin_caller() {
+        let env = Env::default();
+        let id = env.register_contract(None, AdminTestContract);
+        env.as_contract(&id, || {
+            let admin = Address::generate(&env);
+            let attacker = Address::generate(&env);
+            env.storage()
+                .instance()
+                .set(&CommonDataKey::Admin, &admin);
+
+            let result =
+                require_admin_simple!(&env, &attacker, &CommonDataKey::Admin, AdminTestError);
+            assert_eq!(result, Err(AdminTestError::Unauthorized));
+        });
+    }
+
+    /// require_admin_simple! must return Err(NotInitialized) when no admin is stored.
+    #[test]
+    fn require_admin_simple_returns_not_initialized_when_key_absent() {
+        let env = Env::default();
+        let id = env.register_contract(None, AdminTestContract);
+        env.as_contract(&id, || {
+            let caller = Address::generate(&env);
+
+            let result =
+                require_admin_simple!(&env, &caller, &CommonDataKey::Admin, AdminTestError);
+            assert_eq!(result, Err(AdminTestError::NotInitialized));
+        });
+    }
+
+    /// require_admin_simple! and require_admin! are equivalent: both must return
+    /// the same result for the same inputs (key absent, caller is admin, caller
+    /// is not admin).
+    #[test]
+    fn require_admin_simple_matches_require_admin_for_all_cases() {
+        let env = Env::default();
+        let id = env.register_contract(None, AdminTestContract);
+        env.as_contract(&id, || {
+            let admin = Address::generate(&env);
+            let other = Address::generate(&env);
+
+            // ── Case 1: key absent ────────────────────────────────────────────
+            let r_full = require_admin!(
+                &env,
+                &admin,
+                &CommonDataKey::Admin,
+                AdminTestError::NotInitialized,
+                AdminTestError::Unauthorized
+            );
+            let r_simple =
+                require_admin_simple!(&env, &admin, &CommonDataKey::Admin, AdminTestError);
+            assert_eq!(r_full, r_simple);
+
+            // ── Case 2: key present, caller is admin ──────────────────────────
+            env.storage()
+                .instance()
+                .set(&CommonDataKey::Admin, &admin);
+
+            let r_full = require_admin!(
+                &env,
+                &admin,
+                &CommonDataKey::Admin,
+                AdminTestError::NotInitialized,
+                AdminTestError::Unauthorized
+            );
+            let r_simple =
+                require_admin_simple!(&env, &admin, &CommonDataKey::Admin, AdminTestError);
+            assert_eq!(r_full, r_simple);
+
+            // ── Case 3: key present, caller is not admin ──────────────────────
+            let r_full = require_admin!(
+                &env,
+                &other,
+                &CommonDataKey::Admin,
+                AdminTestError::NotInitialized,
+                AdminTestError::Unauthorized
+            );
+            let r_simple =
+                require_admin_simple!(&env, &other, &CommonDataKey::Admin, AdminTestError);
+            assert_eq!(r_full, r_simple);
+        });
     }
 }
 

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -22,6 +22,12 @@
 //! | `router_middleware_total_calls` | Gauge | `contract` | Cumulative pre-call invocations |
 //! | `router_middleware_circuit_open` | Gauge | `contract`, `route` | 1 if the circuit breaker is open |
 //! | `router_middleware_failure_count` | Gauge | `contract`, `route` | Consecutive failure count |
+//! | `router_registry_total_names` | Gauge | `contract` | Total contract names registered in the registry |
+//! | `router_quote_total_generated` | Gauge | `contract` | Running total of quote_generated events |
+//! | `router_quote_total_fee_estimated` | Gauge | `contract` | Running total of fee_estimated events |
+//! | `router_execution_total_executions` | Gauge | `contract` | Cumulative executions recorded on-chain |
+//! | `router_execution_total_errors` | Gauge | `contract` | Cumulative execution errors recorded on-chain |
+//! | `router_execution_max_retries` | Gauge | `contract` | Configured maximum retries read from on-chain storage |
 //! | `router_scrape_duration_seconds` | Histogram | `contract` | Time spent scraping each contract |
 //! | `router_scrape_errors_total` | Counter | `contract` | Number of failed scrape attempts |
 //! | `router_up` | Gauge | — | 1 if the last scrape cycle succeeded |


### PR DESCRIPTION
#900 docs(router-common): remove misleading generic-type annotations
- BatchResult and BatchCallResult are plain structs, not generic over T
- Replaced 'T = BatchUnit' / 'T = CallResult' doc comments with accurate descriptions referencing the actual concrete field types

#901 docs(router-common): correct stale router-middleware event names
- Removed non-existent 'call_logged' and 'route_config_updated' entries
- Fixed 'circuit_breaker_opened' -> 'circuit_opened' (matches EVENT_CIRCUIT_OPENED)
- Added accurate events: pre_call, post_call, rate_limit_throttled, circuit_closed, call_log_cleared (all verified in router-middleware/src/lib.rs)

#902 test(router-common): add unit tests for require_admin! and require_admin_simple!
- Added 7 direct tests in mod tests covering both macros: passes for correct admin, rejects non-admin caller, returns NotInitialized when key absent, and equivalence check

#907 docs(metrics): update main.rs module-doc metrics table
- Added 6 missing metrics: router_registry_total_names, router_quote_total_generated, router_quote_total_fee_estimated, router_execution_total_executions, router_execution_total_errors, router_execution_max_retries (all implemented in src/metrics.rs)
Closes #900 
Closes #901 
Closes #902 
Closes #907 