### PR TITLE
refactor(api-server): remove unused dead-code types RouteBreakdown and WsMessage

### DIFF
--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -180,15 +180,16 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+/// Serves the generated OpenAPI spec as JSON at `/openapi.json`.
+async fn openapi_json() -> Json<utoipa::openapi::OpenApi> {
+    Json(ApiDoc::openapi())
+}
+
 /// Attach a unique `request_id` (UUID v4) to every request span and response header.
 ///
 /// All logs emitted while handling the request inherit the `request_id` field
 /// from the enclosing span, enabling correlation across log lines for a single
 /// request. The ID is also returned to the client in the `X-Request-Id` header.
-async fn openapi_json() -> Json<utoipa::openapi::OpenApi> {
-    Json(ApiDoc::openapi())
-}
-
 async fn request_id_middleware(req: Request<axum::body::Body>, next: Next) -> Response {
     let request_id = uuid::Uuid::new_v4().to_string();
     let method = req.method().clone();

--- a/api-server/src/types.rs
+++ b/api-server/src/types.rs
@@ -70,14 +70,6 @@ pub struct SimulationDetail {
     pub would_succeed: bool,
 }
 
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RouteBreakdown {
-    pub route_name: String,
-    pub version: u32,
-    pub target_contract: String,
-    pub function: String,
-}
 
 /// Machine-readable error codes for API error responses.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -179,9 +171,4 @@ pub struct SubscribeMessage {
     pub tx_id: String,
 }
 
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WsMessage {
-    pub msg_type: String,
-    pub data: serde_json::Value,
-}
+


### PR DESCRIPTION
  The refactor has been implemented with a clean compile. Both dead structs and their                
  #[allow(dead_code)] attributes are gone, and the crate builds without errors.

Closes #917 