### PR TITLE
fix(build): align lint target and .dockerignore with CI/gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ benches/src/scrap-menu/
 
 # Rust build artifacts
 *.wasm
+artifacts/
 
 # Logs
 *.log

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test-all:
 	cargo test --workspace
 
 lint:
-	cargo clippy -- -D warnings
+	cargo clippy --workspace -- -D warnings
 
 build-wasm:
 	cargo build --target wasm32-unknown-unknown --release


### PR DESCRIPTION
## Summary
- `Makefile`'s `lint` target ran `cargo clippy -- -D warnings`, which only lints the root crate. CI (`.github/workflows/ci.yml`) actually runs `cargo clippy --workspace -- -D warnings`. Updated the target to match so `make lint` mirrors CI.
- `.dockerignore` (added in #939) was missing `artifacts/`, which is already excluded in `.gitignore` and was explicitly called out as a required entry in #922.

Related to #921 and #922, which were previously implemented in #939 but missed these two details.

## Validation
- Manually diffed against `.github/workflows/ci.yml` to confirm the clippy invocation now matches.
- Confirmed `artifacts/` is present in `.gitignore` and now mirrored in `.dockerignore`.

closes #921 
closes #922 