### PR TITLE
refactor: extract fee constants and consolidate dependency checks

### DIFF
--- a/.github/workflows/metrics-exporter.yml
+++ b/.github/workflows/metrics-exporter.yml
@@ -2,12 +2,12 @@ name: Metrics Exporter CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
       - 'metrics/**'
       - '.github/workflows/metrics-exporter.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
       - 'metrics/**'
       - '.github/workflows/metrics-exporter.yml'

--- a/api-server/src/rpc.rs
+++ b/api-server/src/rpc.rs
@@ -6,6 +6,12 @@ use tracing::warn;
 
 use crate::types::{RouteEntryResponse, RouteMetadataResponse};
 
+// Fee estimation constants
+const BASE_FEE: i64 = 100;
+const SURGE_THRESHOLD_BPS: u32 = 8_000;
+const SURGE_MULTIPLIER: u32 = 200;
+const NORMAL_MULTIPLIER: u32 = 100;
+
 #[derive(Debug, Clone)]
 pub struct SorobanRpcClient {
     pub rpc_url: String,
@@ -133,11 +139,11 @@ impl SorobanRpcClient {
                         (1_000, false)
                     }
                 };
-                let base_fee: i64 = 100;
-                let (surge_multiplier, high_load) = if network_load_bps >= 8_000 {
-                    (200u32, true)
+                let base_fee = BASE_FEE;
+                let (surge_multiplier, high_load) = if network_load_bps >= SURGE_THRESHOLD_BPS {
+                    (SURGE_MULTIPLIER, true)
                 } else {
-                    (100u32, false)
+                    (NORMAL_MULTIPLIER, false)
                 };
                 let total_fee = (base_fee + resource_fee) * surge_multiplier as i64 / 100;
                 Ok(FeeBreakdown {
@@ -418,7 +424,7 @@ impl SorobanRpcClient {
     }
 
     fn heuristic_estimate(amount: i64, network_load_bps: u32) -> FeeBreakdown {
-        let base_fee: i64 = 100;
+        let base_fee = BASE_FEE;
         let resource_fee: i64 = {
             let scaled = amount / 1_000;
             if scaled < 100 {
@@ -427,10 +433,10 @@ impl SorobanRpcClient {
                 scaled
             }
         };
-        let (surge_multiplier, high_load) = if network_load_bps >= 8_000 {
-            (200u32, true)
+        let (surge_multiplier, high_load) = if network_load_bps >= SURGE_THRESHOLD_BPS {
+            (SURGE_MULTIPLIER, true)
         } else {
-            (100u32, false)
+            (NORMAL_MULTIPLIER, false)
         };
         let total_fee = (base_fee + resource_fee) * surge_multiplier as i64 / 100;
         FeeBreakdown {

--- a/api-server/src/types.rs
+++ b/api-server/src/types.rs
@@ -19,6 +19,8 @@ pub struct SimulateRequest {
     #[serde(default = "default_amount")]
     pub amount: i64,
     /// Fee rate in basis points (default 30 = 0.30%)
+    /// Note: This field is currently unused and reserved for future use.
+    /// Fee estimation currently uses hardcoded constants.
     #[serde(default = "default_fee_bps")]
     pub fee_bps: u32,
     /// Network load in basis points for surge pricing (0–10000)

--- a/contracts/router-core/src/lib.rs
+++ b/contracts/router-core/src/lib.rs
@@ -605,16 +605,8 @@ impl RouterCore {
             return Err(RouterError::RouteNotFound);
         }
 
-        let route_names = Self::get_route_names(&env);
-        for dependent_name in route_names.iter() {
-            if dependent_name != name {
-                let dependencies = Self::get_dependencies_for_route(&env, dependent_name.clone());
-                for dependency in dependencies.iter() {
-                    if dependency == name {
-                        return Err(RouterError::RouteInUse);
-                    }
-                }
-            }
+        if Self::route_has_dependents(&env, &name) {
+            return Err(RouterError::RouteInUse);
         }
 
         env.storage()
@@ -2469,21 +2461,8 @@ impl RouterCore {
             return Err(RouterError::RouteNotFound);
         }
 
-        let route_names = Self::get_route_names(env);
-        for dependent_name in route_names.iter() {
-            if dependent_name != name {
-                let dependencies = Self::get_dependencies_for_route(env, dependent_name.clone());
-                let mut depends_on_removed = false;
-                for dependency in dependencies.iter() {
-                    if dependency == name {
-                        depends_on_removed = true;
-                        break;
-                    }
-                }
-                if depends_on_removed {
-                    return Err(RouterError::RouteInUse);
-                }
-            }
+        if Self::route_has_dependents(env, &name) {
+            return Err(RouterError::RouteInUse);
         }
 
         env.storage()
@@ -2524,6 +2503,30 @@ impl RouterCore {
         );
 
         Ok(())
+    }
+
+    /// Checks if any other route depends on the given route name.
+    ///
+    /// Scans all registered routes to determine if the specified route is
+    /// listed as a dependency by any other route.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment.
+    /// * `name` - The route name to check for dependents.
+    ///
+    /// # Returns
+    /// `true` if at least one other route depends on this route, `false` otherwise.
+    fn route_has_dependents(env: &Env, name: &String) -> bool {
+        for dependent_name in Self::get_route_names(env).iter() {
+            if dependent_name != *name {
+                for dependency in Self::get_dependencies_for_route(env, dependent_name.clone()).iter() {
+                    if dependency == *name {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
     }
 }
 


### PR DESCRIPTION
## Refactor: Code deduplication and maintenance improvements

Closes #960
Closes #961 
Closes #962 
Closes #963

This PR addresses four maintenance issues identified in code review.

### Changes

**1. Deduplicate dependent-route scan loop in router-core**
- Extracted common "route has dependents" check into `route_has_dependents()` helper
- Eliminates copy-paste logic between `remove_route()` and `remove_route_internal()`
- Future changes to dependency checking now only need updating in one location

**2. Extract duplicated fee constants in rpc.rs**
- Introduced module-level constants: `BASE_FEE`, `SURGE_THRESHOLD_BPS`, `SURGE_MULTIPLIER`, `NORMAL_MULTIPLIER`
- Replaced hardcoded values in both `simulate()` and `heuristic_estimate()`
- Ensures consistency between RPC path and heuristic fallback path

**3. Document unused fee_bps field**
- Added doc comment to `SimulateRequest.fee_bps` noting it's currently unused/reserved
- Clarifies that fee estimation uses hardcoded constants for now
- Prevents API consumer confusion about expected behavior

**4. Normalize CI workflow formatting**
- Changed `branches: [ main, develop ]` to `branches: [main, develop]` in metrics-exporter.yml
- Matches bracket-spacing convention used in all other workflow files
- Improves consistency across .github/workflows/

### Impact
- No behavioral changes
- Improves maintainability and code clarity
- Reduces risk of drift in duplicated logic
